### PR TITLE
Change Wezterm leader key to Ctrl+Q

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -1,5 +1,9 @@
 if status is-interactive
     # Commands to run in interactive sessions can go here
+
+    # Disable flow control (XON/XOFF) to allow Ctrl+Q as a keybind in WezTerm
+    stty -ixon
+
   zoxide init fish | source
 end
 

--- a/config/wezterm/wezterm.lua
+++ b/config/wezterm/wezterm.lua
@@ -111,7 +111,7 @@ end
 
 config.keys = keybinds.keys
 config.key_tables = keybinds.key_tables
-config.leader = { key = "t", mods = "CTRL", timeout_milliseconds = 2000 }
+config.leader = { key = "q", mods = "CTRL", timeout_milliseconds = 2000 }
 
 ----------------------------------------------------
 -- event handlers


### PR DESCRIPTION
- Change WezTerm leader key from Ctrl+T to Ctrl+Q to avoid conflict with Neovim's tag jump (Ctrl+T)
- Add stty -ixon to fish config to disable flow control (XON/XOFF) and allow Ctrl+Q as a keybind
- Ctrl+Q doesn't conflict with Neovim/Vim, tmux/screen, or Emacs (Ctrl+A)