### PR TITLE
feat: add Makefile for dotfiles symlink management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,338 @@
+# =============================================================================
+# dotfiles Makefile
+# =============================================================================
+# 単一の入口でOSごとの設定ファイルシンボリックリンクを管理する
+# 冪等性を重視：何度実行しても同じ結果になる
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# シェル設定
+# -----------------------------------------------------------------------------
+# SHELL: 明示的に bash を指定（POSIX sh では一部機能が使えない）
+SHELL := /bin/bash
+
+# .SHELLFLAGS: -e でエラー時即終了、-u で未定義変数エラー、-o pipefail でパイプエラー検知
+.SHELLFLAGS := -eu -o pipefail -c
+
+# .ONESHELL: 1つのターゲット内の複数行を同一シェルで実行（変数共有可能）
+.ONESHELL:
+
+# .DELETE_ON_ERROR: ターゲット実行中にエラーが発生したら生成物を削除
+.DELETE_ON_ERROR:
+
+# -----------------------------------------------------------------------------
+# OS判定
+# -----------------------------------------------------------------------------
+UNAME_S := $(shell uname -s 2>/dev/null || echo "Unknown")
+
+ifeq ($(UNAME_S),Darwin)
+    DETECTED_OS := macos
+else ifeq ($(UNAME_S),Linux)
+    DETECTED_OS := linux
+else ifneq (,$(findstring MINGW,$(UNAME_S)))
+    DETECTED_OS := windows
+else ifneq (,$(findstring MSYS,$(UNAME_S)))
+    DETECTED_OS := windows
+else ifneq (,$(findstring CYGWIN,$(UNAME_S)))
+    DETECTED_OS := windows
+else
+    DETECTED_OS := unknown
+endif
+
+# -----------------------------------------------------------------------------
+# パス定義
+# -----------------------------------------------------------------------------
+DOTFILES_DIR := $(shell pwd)
+CONFIG_DIR := $(DOTFILES_DIR)/config
+XDG_CONFIG_HOME := $(HOME)/.config
+
+# -----------------------------------------------------------------------------
+# リンク対象定義
+# -----------------------------------------------------------------------------
+# 共通設定（全OS）
+COMMON_CONFIGS := nvim wezterm fish tmux
+
+# macOS固有設定
+MACOS_CONFIGS := aerospace karabiner
+
+# Linux固有設定
+LINUX_CONFIGS := ubuntu_nvim
+
+# Windows固有設定（PowerShell）
+# 注: Windowsの場合、PowerShellプロファイルパスは特殊
+WINDOWS_CONFIGS := powershell
+
+# -----------------------------------------------------------------------------
+# オプションフラグ
+# -----------------------------------------------------------------------------
+# FORCE=1 で既存ファイル/ディレクトリを強制削除
+FORCE ?= 0
+
+# VERBOSE=1 で詳細出力
+VERBOSE ?= 0
+
+ifeq ($(VERBOSE),1)
+    Q :=
+    ECHO := @echo
+else
+    Q := @
+    ECHO := @echo
+endif
+
+# -----------------------------------------------------------------------------
+# カラー出力（対応ターミナル用）
+# -----------------------------------------------------------------------------
+COLOR_RESET := \033[0m
+COLOR_GREEN := \033[32m
+COLOR_YELLOW := \033[33m
+COLOR_RED := \033[31m
+COLOR_CYAN := \033[36m
+
+# -----------------------------------------------------------------------------
+# PHONYターゲット宣言
+# -----------------------------------------------------------------------------
+.PHONY: all help link link-macos link-linux link-windows \
+        unlink unlink-macos unlink-linux unlink-windows \
+        check status clean
+
+# -----------------------------------------------------------------------------
+# デフォルトターゲット
+# -----------------------------------------------------------------------------
+all: link
+
+# -----------------------------------------------------------------------------
+# ヘルプ
+# -----------------------------------------------------------------------------
+help:
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_CYAN)dotfiles Makefile$(COLOR_RESET)"
+	$(ECHO) "================="
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_GREEN)使用方法:$(COLOR_RESET)"
+	$(ECHO) "  make link          - 現在のOSに合わせてシンボリックリンクを作成"
+	$(ECHO) "  make link-macos    - macOS用リンクを作成"
+	$(ECHO) "  make link-linux    - Linux用リンクを作成"
+	$(ECHO) "  make link-windows  - Windows用リンクを作成"
+	$(ECHO) ""
+	$(ECHO) "  make unlink        - 現在のOSのシンボリックリンクを削除"
+	$(ECHO) "  make unlink-macos  - macOS用リンクを削除"
+	$(ECHO) "  make unlink-linux  - Linux用リンクを削除"
+	$(ECHO) "  make unlink-windows- Windows用リンクを削除"
+	$(ECHO) ""
+	$(ECHO) "  make status        - 現在のリンク状態を表示"
+	$(ECHO) "  make check         - OS検出結果を表示"
+	$(ECHO) "  make help          - このヘルプを表示"
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_GREEN)オプション:$(COLOR_RESET)"
+	$(ECHO) "  FORCE=1            - 既存ファイル/ディレクトリを強制上書き"
+	$(ECHO) "  VERBOSE=1          - 詳細出力を有効化"
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_GREEN)例:$(COLOR_RESET)"
+	$(ECHO) "  make link                  # 自動OS検出でリンク作成"
+	$(ECHO) "  make link FORCE=1          # 既存ファイルを強制上書き"
+	$(ECHO) "  make link-macos VERBOSE=1  # macOS用、詳細出力"
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_GREEN)検出されたOS:$(COLOR_RESET) $(DETECTED_OS)"
+	$(ECHO) ""
+
+# -----------------------------------------------------------------------------
+# OS検出確認
+# -----------------------------------------------------------------------------
+check:
+	$(ECHO) "$(COLOR_CYAN)OS検出結果$(COLOR_RESET)"
+	$(ECHO) "  uname -s: $(UNAME_S)"
+	$(ECHO) "  検出OS:   $(DETECTED_OS)"
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_CYAN)パス設定$(COLOR_RESET)"
+	$(ECHO) "  DOTFILES_DIR:    $(DOTFILES_DIR)"
+	$(ECHO) "  CONFIG_DIR:      $(CONFIG_DIR)"
+	$(ECHO) "  XDG_CONFIG_HOME: $(XDG_CONFIG_HOME)"
+
+# -----------------------------------------------------------------------------
+# リンク状態確認
+# -----------------------------------------------------------------------------
+status:
+	$(ECHO) "$(COLOR_CYAN)シンボリックリンク状態$(COLOR_RESET)"
+	$(ECHO) ""
+	$(Q)for config in $(COMMON_CONFIGS) $(MACOS_CONFIGS) $(LINUX_CONFIGS); do \
+		target="$(XDG_CONFIG_HOME)/$$config"; \
+		if [ -L "$$target" ]; then \
+			link_dest=$$(readlink "$$target"); \
+			echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $$target -> $$link_dest"; \
+		elif [ -e "$$target" ]; then \
+			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (通常ファイル/ディレクトリ)"; \
+		else \
+			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (存在しない)"; \
+		fi; \
+	done
+
+# -----------------------------------------------------------------------------
+# メインリンクターゲット（OS自動判定）
+# -----------------------------------------------------------------------------
+link:
+ifeq ($(DETECTED_OS),macos)
+	$(ECHO) "$(COLOR_GREEN)macOSを検出しました$(COLOR_RESET)"
+	$(MAKE) link-macos FORCE=$(FORCE) VERBOSE=$(VERBOSE)
+else ifeq ($(DETECTED_OS),linux)
+	$(ECHO) "$(COLOR_GREEN)Linuxを検出しました$(COLOR_RESET)"
+	$(MAKE) link-linux FORCE=$(FORCE) VERBOSE=$(VERBOSE)
+else ifeq ($(DETECTED_OS),windows)
+	$(ECHO) "$(COLOR_GREEN)Windowsを検出しました$(COLOR_RESET)"
+	$(MAKE) link-windows FORCE=$(FORCE) VERBOSE=$(VERBOSE)
+else
+	$(ECHO) "$(COLOR_RED)エラー: 未対応のOS ($(UNAME_S))$(COLOR_RESET)"
+	$(ECHO) ""
+	$(ECHO) "対応OS:"
+	$(ECHO) "  - macOS (Darwin)"
+	$(ECHO) "  - Linux"
+	$(ECHO) "  - Windows (MINGW/MSYS/CYGWIN経由)"
+	$(ECHO) ""
+	$(ECHO) "Windows (PowerShell/cmd.exe) から直接実行する場合は、"
+	$(ECHO) "Git Bash、MSYS2、またはWSLをご利用ください。"
+	exit 1
+endif
+
+# -----------------------------------------------------------------------------
+# macOS用リンク作成
+# -----------------------------------------------------------------------------
+link-macos: _ensure-xdg-config
+	$(ECHO) "$(COLOR_CYAN)macOS: シンボリックリンクを作成します$(COLOR_RESET)"
+	$(ECHO) ""
+	$(Q)for config in $(COMMON_CONFIGS) $(MACOS_CONFIGS); do \
+		$(MAKE) _create-link \
+			SRC="$(CONFIG_DIR)/$$config" \
+			DEST="$(XDG_CONFIG_HOME)/$$config" \
+			FORCE=$(FORCE); \
+	done
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_GREEN)macOS: 完了$(COLOR_RESET)"
+
+# -----------------------------------------------------------------------------
+# Linux用リンク作成
+# -----------------------------------------------------------------------------
+link-linux: _ensure-xdg-config
+	$(ECHO) "$(COLOR_CYAN)Linux: シンボリックリンクを作成します$(COLOR_RESET)"
+	$(ECHO) ""
+	$(Q)for config in $(COMMON_CONFIGS) $(LINUX_CONFIGS); do \
+		$(MAKE) _create-link \
+			SRC="$(CONFIG_DIR)/$$config" \
+			DEST="$(XDG_CONFIG_HOME)/$$config" \
+			FORCE=$(FORCE); \
+	done
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_GREEN)Linux: 完了$(COLOR_RESET)"
+
+# -----------------------------------------------------------------------------
+# Windows用リンク作成
+# -----------------------------------------------------------------------------
+# Windows (Git Bash/MSYS2/Cygwin) でのシンボリックリンク作成
+# 注: 管理者権限が必要な場合があります
+link-windows: _ensure-xdg-config
+	$(ECHO) "$(COLOR_CYAN)Windows: シンボリックリンクを作成します$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_YELLOW)注: 管理者権限が必要な場合があります$(COLOR_RESET)"
+	$(ECHO) ""
+	$(Q)for config in $(COMMON_CONFIGS); do \
+		$(MAKE) _create-link \
+			SRC="$(CONFIG_DIR)/$$config" \
+			DEST="$(XDG_CONFIG_HOME)/$$config" \
+			FORCE=$(FORCE); \
+	done
+	@# PowerShell プロファイル用の特殊処理
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_YELLOW)PowerShellプロファイルは手動設定が必要な場合があります:$(COLOR_RESET)"
+	$(ECHO) "  ソース: $(CONFIG_DIR)/powershell"
+	$(ECHO) "  推奨先: \$$HOME\\Documents\\PowerShell"
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_GREEN)Windows: 完了$(COLOR_RESET)"
+
+# -----------------------------------------------------------------------------
+# リンク削除ターゲット
+# -----------------------------------------------------------------------------
+unlink:
+ifeq ($(DETECTED_OS),macos)
+	$(MAKE) unlink-macos
+else ifeq ($(DETECTED_OS),linux)
+	$(MAKE) unlink-linux
+else ifeq ($(DETECTED_OS),windows)
+	$(MAKE) unlink-windows
+else
+	$(ECHO) "$(COLOR_RED)エラー: 未対応のOS$(COLOR_RESET)"
+	exit 1
+endif
+
+unlink-macos:
+	$(ECHO) "$(COLOR_CYAN)macOS: シンボリックリンクを削除します$(COLOR_RESET)"
+	$(Q)for config in $(COMMON_CONFIGS) $(MACOS_CONFIGS); do \
+		$(MAKE) _remove-link DEST="$(XDG_CONFIG_HOME)/$$config"; \
+	done
+	$(ECHO) "$(COLOR_GREEN)macOS: リンク削除完了$(COLOR_RESET)"
+
+unlink-linux:
+	$(ECHO) "$(COLOR_CYAN)Linux: シンボリックリンクを削除します$(COLOR_RESET)"
+	$(Q)for config in $(COMMON_CONFIGS) $(LINUX_CONFIGS); do \
+		$(MAKE) _remove-link DEST="$(XDG_CONFIG_HOME)/$$config"; \
+	done
+	$(ECHO) "$(COLOR_GREEN)Linux: リンク削除完了$(COLOR_RESET)"
+
+unlink-windows:
+	$(ECHO) "$(COLOR_CYAN)Windows: シンボリックリンクを削除します$(COLOR_RESET)"
+	$(Q)for config in $(COMMON_CONFIGS); do \
+		$(MAKE) _remove-link DEST="$(XDG_CONFIG_HOME)/$$config"; \
+	done
+	$(ECHO) "$(COLOR_GREEN)Windows: リンク削除完了$(COLOR_RESET)"
+
+# -----------------------------------------------------------------------------
+# 内部ターゲット: XDG_CONFIG_HOME ディレクトリ作成
+# -----------------------------------------------------------------------------
+_ensure-xdg-config:
+	$(Q)if [ ! -d "$(XDG_CONFIG_HOME)" ]; then \
+		echo -e "$(COLOR_YELLOW)$(XDG_CONFIG_HOME) を作成します$(COLOR_RESET)"; \
+		mkdir -p "$(XDG_CONFIG_HOME)"; \
+	fi
+
+# -----------------------------------------------------------------------------
+# 内部ターゲット: シンボリックリンク作成
+# -----------------------------------------------------------------------------
+# 引数: SRC=ソースパス DEST=リンク先パス FORCE=強制フラグ
+_create-link:
+	@# ソースの存在確認
+	$(Q)if [ ! -e "$(SRC)" ]; then \
+		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(SRC) (ソースが存在しません)"; \
+		exit 0; \
+	fi
+	@# リンク先の状態確認と処理
+	$(Q)if [ -L "$(DEST)" ]; then \
+		echo -e "  $(COLOR_YELLOW)[DEL]$(COLOR_RESET)  既存リンクを削除: $(DEST)"; \
+		rm "$(DEST)"; \
+	elif [ -e "$(DEST)" ]; then \
+		if [ "$(FORCE)" = "1" ]; then \
+			echo -e "  $(COLOR_RED)[FORCE]$(COLOR_RESET) 既存を強制削除: $(DEST)"; \
+			rm -rf "$(DEST)"; \
+		else \
+			echo -e "  $(COLOR_RED)[ERROR]$(COLOR_RESET) $(DEST) は通常ファイル/ディレクトリです"; \
+			echo -e "         強制削除するには FORCE=1 を指定してください"; \
+			exit 1; \
+		fi; \
+	fi
+	@# シンボリックリンク作成
+	$(Q)ln -s "$(SRC)" "$(DEST)"
+	$(Q)echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $(DEST) -> $(SRC)"
+
+# -----------------------------------------------------------------------------
+# 内部ターゲット: シンボリックリンク削除
+# -----------------------------------------------------------------------------
+# 引数: DEST=リンクパス
+_remove-link:
+	$(Q)if [ -L "$(DEST)" ]; then \
+		rm "$(DEST)"; \
+		echo -e "  $(COLOR_GREEN)[DEL]$(COLOR_RESET)  $(DEST)"; \
+	elif [ -e "$(DEST)" ]; then \
+		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(DEST) (シンボリックリンクではありません)"; \
+	else \
+		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(DEST) (存在しません)"; \
+	fi
+
+# -----------------------------------------------------------------------------
+# クリーンアップ（全リンク削除の別名）
+# -----------------------------------------------------------------------------
+clean: unlink

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,13 @@
 # Shell settings
 # -----------------------------------------------------------------------------
 # SHELL: Use bash explicitly (some features require more than POSIX sh)
+# On Windows, derive Git for Windows bash from git --exec-path
+# (PATH may only have WSL's bash.exe, not Git's)
+ifdef ComSpec
+SHELL := $(subst mingw64/libexec/git-core,bin/bash.exe,$(subst \,/,$(shell git --exec-path 2>nul)))
+else
 SHELL := /bin/bash
+endif
 
 # .SHELLFLAGS: -e exits on error, -u errors on undefined vars, -o pipefail catches pipe errors
 .SHELLFLAGS := -eu -o pipefail -c

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,27 @@
 # =============================================================================
 # dotfiles Makefile
 # =============================================================================
-# 単一の入口でOSごとの設定ファイルシンボリックリンクを管理する
-# 冪等性を重視：何度実行しても同じ結果になる
+# Orchestrate dotfiles symlink management from a single entry point
+# Idempotent: running multiple times always produces the same result
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# シェル設定
+# Shell settings
 # -----------------------------------------------------------------------------
-# SHELL: 明示的に bash を指定（POSIX sh では一部機能が使えない）
+# SHELL: Use bash explicitly (some features require more than POSIX sh)
 SHELL := /bin/bash
 
-# .SHELLFLAGS: -e でエラー時即終了、-u で未定義変数エラー、-o pipefail でパイプエラー検知
+# .SHELLFLAGS: -e exits on error, -u errors on undefined vars, -o pipefail catches pipe errors
 .SHELLFLAGS := -eu -o pipefail -c
 
-# .ONESHELL: 1つのターゲット内の複数行を同一シェルで実行（変数共有可能）
+# .ONESHELL: Run all lines in a target within the same shell (enables variable sharing)
 .ONESHELL:
 
-# .DELETE_ON_ERROR: ターゲット実行中にエラーが発生したら生成物を削除
+# .DELETE_ON_ERROR: Remove target files if a recipe fails
 .DELETE_ON_ERROR:
 
 # -----------------------------------------------------------------------------
-# OS判定
+# OS detection
 # -----------------------------------------------------------------------------
 UNAME_S := $(shell uname -s 2>/dev/null || echo "Unknown")
 
@@ -40,58 +40,58 @@ else
 endif
 
 # -----------------------------------------------------------------------------
-# パス定義
+# Path definitions
 # -----------------------------------------------------------------------------
 DOTFILES_DIR := $(shell pwd)
 CONFIG_DIR := $(DOTFILES_DIR)/config
 XDG_CONFIG_HOME := $(HOME)/.config
 
 # -----------------------------------------------------------------------------
-# リンク対象定義
+# Link targets
 # -----------------------------------------------------------------------------
-# ディレクトリ単位でリンクする設定（全OS共通）
+# Directory-level symlinks (all OS)
 COMMON_CONFIGS := nvim wezterm tmux
 
-# ディレクトリ単位でリンクする設定（macOS固有）
+# Directory-level symlinks (macOS only)
 MACOS_CONFIGS := aerospace
 
-# ディレクトリ単位でリンクする設定（Linux固有）
+# Directory-level symlinks (Linux only)
 LINUX_CONFIGS := ubuntu_nvim
 
-# ディレクトリ単位でリンクする設定（Windows固有）
-# 注: Windowsの場合、PowerShellプロファイルパスは特殊
+# Directory-level symlinks (Windows only)
+# Note: PowerShell profile path is special on Windows
 WINDOWS_CONFIGS := powershell
 
 # -----------------------------------------------------------------------------
-# ファイル単位リンク対象定義
+# File-level link targets
 # -----------------------------------------------------------------------------
-# fish: 環境依存ファイル（fish_variables等）を除外するためファイル単位で管理
-# 注: functions/, completions/, conf.d/ 内のファイルも個別にリンク
+# fish: Linked per-file to exclude env-dependent files (fish_variables, etc.)
+# Note: Files in functions/, completions/, conf.d/ are also linked individually
 FISH_FILES := config.fish abbr.fish
 FISH_SUBDIRS := functions completions conf.d
 
-# karabiner: メイン設定(karabiner.json)は環境依存のためカスタムルールのみ管理
+# karabiner: Only custom rules are managed (karabiner.json is env-dependent)
 KARABINER_FILES := numpad.json
 
 # -----------------------------------------------------------------------------
-# オプションフラグ
+# Option flags
 # -----------------------------------------------------------------------------
-# FORCE=1 で既存ファイル/ディレクトリを強制削除
+# FORCE=1 to force-remove existing files/directories
 FORCE ?= 0
 
-# VERBOSE=1 で詳細出力
+# VERBOSE=1 for verbose output
 VERBOSE ?= 0
 
 ifeq ($(VERBOSE),1)
     Q :=
-    ECHO := @echo
+    ECHO := @echo -e
 else
     Q := @
-    ECHO := @echo
+    ECHO := @echo -e
 endif
 
 # -----------------------------------------------------------------------------
-# カラー出力（対応ターミナル用）
+# Color output (for supported terminals)
 # -----------------------------------------------------------------------------
 COLOR_RESET := \033[0m
 COLOR_GREEN := \033[32m
@@ -100,7 +100,7 @@ COLOR_RED := \033[31m
 COLOR_CYAN := \033[36m
 
 # -----------------------------------------------------------------------------
-# PHONYターゲット宣言
+# PHONY targets
 # -----------------------------------------------------------------------------
 .PHONY: all help link link-macos link-linux link-windows \
         unlink unlink-macos unlink-linux unlink-windows \
@@ -110,87 +110,87 @@ COLOR_CYAN := \033[36m
         _link-karabiner-files _unlink-karabiner-files
 
 # -----------------------------------------------------------------------------
-# デフォルトターゲット
+# Default target
 # -----------------------------------------------------------------------------
 all: link
 
 # -----------------------------------------------------------------------------
-# ヘルプ
+# Help
 # -----------------------------------------------------------------------------
 help:
 	$(ECHO) ""
 	$(ECHO) "$(COLOR_CYAN)dotfiles Makefile$(COLOR_RESET)"
 	$(ECHO) "================="
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_GREEN)使用方法:$(COLOR_RESET)"
-	$(ECHO) "  make link          - 現在のOSに合わせてシンボリックリンクを作成"
-	$(ECHO) "  make link-macos    - macOS用リンクを作成"
-	$(ECHO) "  make link-linux    - Linux用リンクを作成"
-	$(ECHO) "  make link-windows  - Windows用リンクを作成"
+	$(ECHO) "$(COLOR_GREEN)Usage:$(COLOR_RESET)"
+	$(ECHO) "  make link          - Create symlinks for the detected OS"
+	$(ECHO) "  make link-macos    - Create symlinks for macOS"
+	$(ECHO) "  make link-linux    - Create symlinks for Linux"
+	$(ECHO) "  make link-windows  - Create symlinks for Windows"
 	$(ECHO) ""
-	$(ECHO) "  make unlink        - 現在のOSのシンボリックリンクを削除"
-	$(ECHO) "  make unlink-macos  - macOS用リンクを削除"
-	$(ECHO) "  make unlink-linux  - Linux用リンクを削除"
-	$(ECHO) "  make unlink-windows- Windows用リンクを削除"
+	$(ECHO) "  make unlink        - Remove symlinks for the detected OS"
+	$(ECHO) "  make unlink-macos  - Remove symlinks for macOS"
+	$(ECHO) "  make unlink-linux  - Remove symlinks for Linux"
+	$(ECHO) "  make unlink-windows- Remove symlinks for Windows"
 	$(ECHO) ""
-	$(ECHO) "  make status        - 現在のリンク状態を表示"
-	$(ECHO) "  make check         - OS検出結果を表示"
-	$(ECHO) "  make help          - このヘルプを表示"
+	$(ECHO) "  make status        - Show current symlink status"
+	$(ECHO) "  make check         - Show OS detection result"
+	$(ECHO) "  make help          - Show this help"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_GREEN)オプション:$(COLOR_RESET)"
-	$(ECHO) "  FORCE=1            - 既存ファイル/ディレクトリを強制上書き"
-	$(ECHO) "  VERBOSE=1          - 詳細出力を有効化"
+	$(ECHO) "$(COLOR_GREEN)Options:$(COLOR_RESET)"
+	$(ECHO) "  FORCE=1            - Force overwrite existing files/directories"
+	$(ECHO) "  VERBOSE=1          - Enable verbose output"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_GREEN)例:$(COLOR_RESET)"
-	$(ECHO) "  make link                  # 自動OS検出でリンク作成"
-	$(ECHO) "  make link FORCE=1          # 既存ファイルを強制上書き"
-	$(ECHO) "  make link-macos VERBOSE=1  # macOS用、詳細出力"
+	$(ECHO) "$(COLOR_GREEN)Examples:$(COLOR_RESET)"
+	$(ECHO) "  make link                  # Auto-detect OS and create links"
+	$(ECHO) "  make link FORCE=1          # Force overwrite existing files"
+	$(ECHO) "  make link-macos VERBOSE=1  # macOS links with verbose output"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_GREEN)検出されたOS:$(COLOR_RESET) $(DETECTED_OS)"
+	$(ECHO) "$(COLOR_GREEN)Detected OS:$(COLOR_RESET) $(DETECTED_OS)"
 	$(ECHO) ""
 
 # -----------------------------------------------------------------------------
-# OS検出確認
+# OS detection check
 # -----------------------------------------------------------------------------
 check:
-	$(ECHO) "$(COLOR_CYAN)OS検出結果$(COLOR_RESET)"
-	$(ECHO) "  uname -s: $(UNAME_S)"
-	$(ECHO) "  検出OS:   $(DETECTED_OS)"
+	$(ECHO) "$(COLOR_CYAN)OS Detection$(COLOR_RESET)"
+	$(ECHO) "  uname -s:    $(UNAME_S)"
+	$(ECHO) "  Detected OS: $(DETECTED_OS)"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)パス設定$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)Paths$(COLOR_RESET)"
 	$(ECHO) "  DOTFILES_DIR:    $(DOTFILES_DIR)"
 	$(ECHO) "  CONFIG_DIR:      $(CONFIG_DIR)"
 	$(ECHO) "  XDG_CONFIG_HOME: $(XDG_CONFIG_HOME)"
 
 # -----------------------------------------------------------------------------
-# リンク状態確認
+# Symlink status
 # -----------------------------------------------------------------------------
 status:
-	$(ECHO) "$(COLOR_CYAN)シンボリックリンク状態$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)Symlink Status$(COLOR_RESET)"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ディレクトリ単位]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[Directory-level]$(COLOR_RESET)"
 	$(Q)for config in $(COMMON_CONFIGS) $(MACOS_CONFIGS) $(LINUX_CONFIGS); do \
 		target="$(XDG_CONFIG_HOME)/$$config"; \
 		if [ -L "$$target" ]; then \
 			link_dest=$$(readlink "$$target"); \
 			echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $$target -> $$link_dest"; \
 		elif [ -e "$$target" ]; then \
-			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (通常ファイル/ディレクトリ)"; \
+			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (regular file/directory)"; \
 		else \
-			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (存在しない)"; \
+			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
 		fi; \
 	done
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ファイル単位: fish]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[File-level: fish]$(COLOR_RESET)"
 	$(Q)for file in $(FISH_FILES); do \
 		target="$(XDG_CONFIG_HOME)/fish/$$file"; \
 		if [ -L "$$target" ]; then \
 			link_dest=$$(readlink "$$target"); \
 			echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $$target -> $$link_dest"; \
 		elif [ -e "$$target" ]; then \
-			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (通常ファイル)"; \
+			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (regular file)"; \
 		else \
-			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (存在しない)"; \
+			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
 		fi; \
 	done
 	$(Q)for subdir in $(FISH_SUBDIRS); do \
@@ -211,52 +211,52 @@ status:
 		fi; \
 	done
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ファイル単位: karabiner]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[File-level: karabiner]$(COLOR_RESET)"
 	$(Q)for file in $(KARABINER_FILES); do \
 		target="$(XDG_CONFIG_HOME)/karabiner/$$file"; \
 		if [ -L "$$target" ]; then \
 			link_dest=$$(readlink "$$target"); \
 			echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $$target -> $$link_dest"; \
 		elif [ -e "$$target" ]; then \
-			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (通常ファイル)"; \
+			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (regular file)"; \
 		else \
-			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (存在しない)"; \
+			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
 		fi; \
 	done
 
 # -----------------------------------------------------------------------------
-# メインリンクターゲット（OS自動判定）
+# Main link target (auto-detect OS)
 # -----------------------------------------------------------------------------
 link:
 ifeq ($(DETECTED_OS),macos)
-	$(ECHO) "$(COLOR_GREEN)macOSを検出しました$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)Detected macOS$(COLOR_RESET)"
 	$(MAKE) link-macos FORCE=$(FORCE) VERBOSE=$(VERBOSE)
 else ifeq ($(DETECTED_OS),linux)
-	$(ECHO) "$(COLOR_GREEN)Linuxを検出しました$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)Detected Linux$(COLOR_RESET)"
 	$(MAKE) link-linux FORCE=$(FORCE) VERBOSE=$(VERBOSE)
 else ifeq ($(DETECTED_OS),windows)
-	$(ECHO) "$(COLOR_GREEN)Windowsを検出しました$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)Detected Windows$(COLOR_RESET)"
 	$(MAKE) link-windows FORCE=$(FORCE) VERBOSE=$(VERBOSE)
 else
-	$(ECHO) "$(COLOR_RED)エラー: 未対応のOS ($(UNAME_S))$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_RED)Error: Unsupported OS ($(UNAME_S))$(COLOR_RESET)"
 	$(ECHO) ""
-	$(ECHO) "対応OS:"
+	$(ECHO) "Supported:"
 	$(ECHO) "  - macOS (Darwin)"
 	$(ECHO) "  - Linux"
-	$(ECHO) "  - Windows (MINGW/MSYS/CYGWIN経由)"
+	$(ECHO) "  - Windows (via MINGW/MSYS/CYGWIN)"
 	$(ECHO) ""
-	$(ECHO) "Windows (PowerShell/cmd.exe) から直接実行する場合は、"
-	$(ECHO) "Git Bash、MSYS2、またはWSLをご利用ください。"
+	$(ECHO) "If running from PowerShell/cmd.exe directly,"
+	$(ECHO) "please use Git Bash, MSYS2, or WSL."
 	exit 1
 endif
 
 # -----------------------------------------------------------------------------
-# macOS用リンク作成
+# macOS link creation
 # -----------------------------------------------------------------------------
 link-macos: _ensure-xdg-config
-	$(ECHO) "$(COLOR_CYAN)macOS: シンボリックリンクを作成します$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)macOS: Creating symlinks$(COLOR_RESET)"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ディレクトリ単位]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[Directory-level]$(COLOR_RESET)"
 	$(Q)for config in $(COMMON_CONFIGS) $(MACOS_CONFIGS); do \
 		$(MAKE) _create-link \
 			SRC="$(CONFIG_DIR)/$$config" \
@@ -264,21 +264,21 @@ link-macos: _ensure-xdg-config
 			FORCE=$(FORCE); \
 	done
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ファイル単位: fish]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[File-level: fish]$(COLOR_RESET)"
 	$(Q)$(MAKE) _link-fish-files FORCE=$(FORCE)
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ファイル単位: karabiner]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[File-level: karabiner]$(COLOR_RESET)"
 	$(Q)$(MAKE) _link-karabiner-files FORCE=$(FORCE)
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_GREEN)macOS: 完了$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)macOS: Done$(COLOR_RESET)"
 
 # -----------------------------------------------------------------------------
-# Linux用リンク作成
+# Linux link creation
 # -----------------------------------------------------------------------------
 link-linux: _ensure-xdg-config
-	$(ECHO) "$(COLOR_CYAN)Linux: シンボリックリンクを作成します$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)Linux: Creating symlinks$(COLOR_RESET)"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ディレクトリ単位]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[Directory-level]$(COLOR_RESET)"
 	$(Q)for config in $(COMMON_CONFIGS) $(LINUX_CONFIGS); do \
 		$(MAKE) _create-link \
 			SRC="$(CONFIG_DIR)/$$config" \
@@ -286,21 +286,21 @@ link-linux: _ensure-xdg-config
 			FORCE=$(FORCE); \
 	done
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ファイル単位: fish]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[File-level: fish]$(COLOR_RESET)"
 	$(Q)$(MAKE) _link-fish-files FORCE=$(FORCE)
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_GREEN)Linux: 完了$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)Linux: Done$(COLOR_RESET)"
 
 # -----------------------------------------------------------------------------
-# Windows用リンク作成
+# Windows link creation
 # -----------------------------------------------------------------------------
-# Windows (Git Bash/MSYS2/Cygwin) でのシンボリックリンク作成
-# 注: 管理者権限が必要な場合があります
+# Windows (Git Bash/MSYS2/Cygwin) symlink creation
+# Note: May require administrator privileges
 link-windows: _ensure-xdg-config
-	$(ECHO) "$(COLOR_CYAN)Windows: シンボリックリンクを作成します$(COLOR_RESET)"
-	$(ECHO) "$(COLOR_YELLOW)注: 管理者権限が必要な場合があります$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)Windows: Creating symlinks$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_YELLOW)Note: Administrator privileges may be required$(COLOR_RESET)"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ディレクトリ単位]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[Directory-level]$(COLOR_RESET)"
 	$(Q)for config in $(COMMON_CONFIGS); do \
 		$(MAKE) _create-link \
 			SRC="$(CONFIG_DIR)/$$config" \
@@ -308,18 +308,18 @@ link-windows: _ensure-xdg-config
 			FORCE=$(FORCE); \
 	done
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[ファイル単位: fish]$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)[File-level: fish]$(COLOR_RESET)"
 	$(Q)$(MAKE) _link-fish-files FORCE=$(FORCE)
-	@# PowerShell プロファイル用の特殊処理
+	@# PowerShell profile needs special handling
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_YELLOW)PowerShellプロファイルは手動設定が必要な場合があります:$(COLOR_RESET)"
-	$(ECHO) "  ソース: $(CONFIG_DIR)/powershell"
-	$(ECHO) "  推奨先: \$$HOME\\Documents\\PowerShell"
+	$(ECHO) "$(COLOR_YELLOW)PowerShell profile may need manual setup:$(COLOR_RESET)"
+	$(ECHO) "  Source: $(CONFIG_DIR)/powershell"
+	$(ECHO) "  Target: \$$HOME\\Documents\\PowerShell"
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_GREEN)Windows: 完了$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)Windows: Done$(COLOR_RESET)"
 
 # -----------------------------------------------------------------------------
-# リンク削除ターゲット
+# Unlink targets
 # -----------------------------------------------------------------------------
 unlink:
 ifeq ($(DETECTED_OS),macos)
@@ -329,94 +329,94 @@ else ifeq ($(DETECTED_OS),linux)
 else ifeq ($(DETECTED_OS),windows)
 	$(MAKE) unlink-windows
 else
-	$(ECHO) "$(COLOR_RED)エラー: 未対応のOS$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_RED)Error: Unsupported OS$(COLOR_RESET)"
 	exit 1
 endif
 
 unlink-macos:
-	$(ECHO) "$(COLOR_CYAN)macOS: シンボリックリンクを削除します$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)macOS: Removing symlinks$(COLOR_RESET)"
 	$(Q)for config in $(COMMON_CONFIGS) $(MACOS_CONFIGS); do \
 		$(MAKE) _remove-link DEST="$(XDG_CONFIG_HOME)/$$config"; \
 	done
 	$(Q)$(MAKE) _unlink-fish-files
 	$(Q)$(MAKE) _unlink-karabiner-files
-	$(ECHO) "$(COLOR_GREEN)macOS: リンク削除完了$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)macOS: Unlink complete$(COLOR_RESET)"
 
 unlink-linux:
-	$(ECHO) "$(COLOR_CYAN)Linux: シンボリックリンクを削除します$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)Linux: Removing symlinks$(COLOR_RESET)"
 	$(Q)for config in $(COMMON_CONFIGS) $(LINUX_CONFIGS); do \
 		$(MAKE) _remove-link DEST="$(XDG_CONFIG_HOME)/$$config"; \
 	done
 	$(Q)$(MAKE) _unlink-fish-files
-	$(ECHO) "$(COLOR_GREEN)Linux: リンク削除完了$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)Linux: Unlink complete$(COLOR_RESET)"
 
 unlink-windows:
-	$(ECHO) "$(COLOR_CYAN)Windows: シンボリックリンクを削除します$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_CYAN)Windows: Removing symlinks$(COLOR_RESET)"
 	$(Q)for config in $(COMMON_CONFIGS); do \
 		$(MAKE) _remove-link DEST="$(XDG_CONFIG_HOME)/$$config"; \
 	done
 	$(Q)$(MAKE) _unlink-fish-files
-	$(ECHO) "$(COLOR_GREEN)Windows: リンク削除完了$(COLOR_RESET)"
+	$(ECHO) "$(COLOR_GREEN)Windows: Unlink complete$(COLOR_RESET)"
 
 # -----------------------------------------------------------------------------
-# 内部ターゲット: XDG_CONFIG_HOME ディレクトリ作成
+# Internal: Ensure XDG_CONFIG_HOME directory exists
 # -----------------------------------------------------------------------------
 _ensure-xdg-config:
 	$(Q)if [ ! -d "$(XDG_CONFIG_HOME)" ]; then \
-		echo -e "$(COLOR_YELLOW)$(XDG_CONFIG_HOME) を作成します$(COLOR_RESET)"; \
+		echo -e "$(COLOR_YELLOW)Creating $(XDG_CONFIG_HOME)$(COLOR_RESET)"; \
 		mkdir -p "$(XDG_CONFIG_HOME)"; \
 	fi
 
 # -----------------------------------------------------------------------------
-# 内部ターゲット: シンボリックリンク作成
+# Internal: Create a symlink
 # -----------------------------------------------------------------------------
-# 引数: SRC=ソースパス DEST=リンク先パス FORCE=強制フラグ
+# Args: SRC=source path  DEST=link path  FORCE=force flag
 _create-link:
-	@# ソースの存在確認
+	@# Check source exists
 	$(Q)if [ ! -e "$(SRC)" ]; then \
-		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(SRC) (ソースが存在しません)"; \
+		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(SRC) (source not found)"; \
 		exit 0; \
 	fi
-	@# リンク先の状態確認と処理
+	@# Check destination state and handle accordingly
 	$(Q)if [ -L "$(DEST)" ]; then \
-		echo -e "  $(COLOR_YELLOW)[DEL]$(COLOR_RESET)  既存リンクを削除: $(DEST)"; \
+		echo -e "  $(COLOR_YELLOW)[DEL]$(COLOR_RESET)  Removing existing link: $(DEST)"; \
 		rm "$(DEST)"; \
 	elif [ -e "$(DEST)" ]; then \
 		if [ "$(FORCE)" = "1" ]; then \
-			echo -e "  $(COLOR_RED)[FORCE]$(COLOR_RESET) 既存を強制削除: $(DEST)"; \
+			echo -e "  $(COLOR_RED)[FORCE]$(COLOR_RESET) Force removing: $(DEST)"; \
 			rm -rf "$(DEST)"; \
 		else \
-			echo -e "  $(COLOR_RED)[ERROR]$(COLOR_RESET) $(DEST) は通常ファイル/ディレクトリです"; \
-			echo -e "         強制削除するには FORCE=1 を指定してください"; \
+			echo -e "  $(COLOR_RED)[ERROR]$(COLOR_RESET) $(DEST) is a regular file/directory"; \
+			echo -e "         Use FORCE=1 to overwrite"; \
 			exit 1; \
 		fi; \
 	fi
-	@# シンボリックリンク作成
+	@# Create symlink
 	$(Q)ln -s "$(SRC)" "$(DEST)"
 	$(Q)echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $(DEST) -> $(SRC)"
 
 # -----------------------------------------------------------------------------
-# 内部ターゲット: シンボリックリンク削除
+# Internal: Remove a symlink
 # -----------------------------------------------------------------------------
-# 引数: DEST=リンクパス
+# Args: DEST=link path
 _remove-link:
 	$(Q)if [ -L "$(DEST)" ]; then \
 		rm "$(DEST)"; \
 		echo -e "  $(COLOR_GREEN)[DEL]$(COLOR_RESET)  $(DEST)"; \
 	elif [ -e "$(DEST)" ]; then \
-		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(DEST) (シンボリックリンクではありません)"; \
+		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(DEST) (not a symlink)"; \
 	else \
-		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(DEST) (存在しません)"; \
+		echo -e "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) $(DEST) (not found)"; \
 	fi
 
 # -----------------------------------------------------------------------------
-# 内部ターゲット: fish ファイル単位リンク作成
+# Internal: Create fish file-level symlinks
 # -----------------------------------------------------------------------------
-# fish は環境依存ファイル（fish_variables等）を除外するためファイル単位でリンク
+# fish is linked per-file to exclude env-dependent files (fish_variables, etc.)
 _link-fish-files:
-	@# ~/.config/fish ディレクトリがなければ作成
+	@# Create ~/.config/fish if missing
 	$(Q)mkdir -p "$(XDG_CONFIG_HOME)/fish"
-	@# ルートレベルのファイルをリンク
+	@# Link root-level files
 	$(Q)for file in $(FISH_FILES); do \
 		src="$(CONFIG_DIR)/fish/$$file"; \
 		dest="$(XDG_CONFIG_HOME)/fish/$$file"; \
@@ -424,7 +424,7 @@ _link-fish-files:
 			$(MAKE) _create-link SRC="$$src" DEST="$$dest" FORCE=$(FORCE); \
 		fi; \
 	done
-	@# サブディレクトリ内のファイルをリンク
+	@# Link files in subdirectories
 	$(Q)for subdir in $(FISH_SUBDIRS); do \
 		src_dir="$(CONFIG_DIR)/fish/$$subdir"; \
 		dest_dir="$(XDG_CONFIG_HOME)/fish/$$subdir"; \
@@ -439,15 +439,15 @@ _link-fish-files:
 	done
 
 # -----------------------------------------------------------------------------
-# 内部ターゲット: fish ファイル単位リンク削除
+# Internal: Remove fish file-level symlinks
 # -----------------------------------------------------------------------------
 _unlink-fish-files:
-	@# ルートレベルのファイルを削除
+	@# Remove root-level files
 	$(Q)for file in $(FISH_FILES); do \
 		dest="$(XDG_CONFIG_HOME)/fish/$$file"; \
 		$(MAKE) _remove-link DEST="$$dest"; \
 	done
-	@# サブディレクトリ内のファイルを削除
+	@# Remove files in subdirectories
 	$(Q)for subdir in $(FISH_SUBDIRS); do \
 		src_dir="$(CONFIG_DIR)/fish/$$subdir"; \
 		dest_dir="$(XDG_CONFIG_HOME)/fish/$$subdir"; \
@@ -461,11 +461,11 @@ _unlink-fish-files:
 	done
 
 # -----------------------------------------------------------------------------
-# 内部ターゲット: karabiner ファイル単位リンク作成
+# Internal: Create karabiner file-level symlinks
 # -----------------------------------------------------------------------------
-# karabiner はメイン設定(karabiner.json)が環境依存のためカスタムルールのみリンク
+# karabiner.json is env-dependent, so only custom rules are linked
 _link-karabiner-files:
-	@# ~/.config/karabiner ディレクトリがなければ作成
+	@# Create ~/.config/karabiner if missing
 	$(Q)mkdir -p "$(XDG_CONFIG_HOME)/karabiner"
 	$(Q)for file in $(KARABINER_FILES); do \
 		src="$(CONFIG_DIR)/karabiner/$$file"; \
@@ -476,7 +476,7 @@ _link-karabiner-files:
 	done
 
 # -----------------------------------------------------------------------------
-# 内部ターゲット: karabiner ファイル単位リンク削除
+# Internal: Remove karabiner file-level symlinks
 # -----------------------------------------------------------------------------
 _unlink-karabiner-files:
 	$(Q)for file in $(KARABINER_FILES); do \
@@ -485,6 +485,6 @@ _unlink-karabiner-files:
 	done
 
 # -----------------------------------------------------------------------------
-# クリーンアップ（全リンク削除の別名）
+# Cleanup (alias for unlink)
 # -----------------------------------------------------------------------------
 clean: unlink

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,8 @@ ifeq ($(DETECTED_OS),windows)
 		echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
 	fi
 endif
+	@# fish and karabiner: not used on Windows
+ifneq ($(DETECTED_OS),windows)
 	$(ECHO) ""
 	$(ECHO) "$(COLOR_CYAN)[File-level: fish]$(COLOR_RESET)"
 	$(Q)for file in $(FISH_FILES); do \
@@ -252,6 +254,7 @@ endif
 			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
 		fi; \
 	done
+endif
 
 # -----------------------------------------------------------------------------
 # Main link target (auto-detect OS)

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,13 @@ LOCALAPPDATA ?= $(HOME)/AppData/Local
 # Link targets
 # -----------------------------------------------------------------------------
 # Directory-level symlinks (all OS)
-COMMON_CONFIGS := wezterm tmux
+COMMON_CONFIGS := wezterm
 
 # Directory-level symlinks (macOS only)
-MACOS_CONFIGS := nvim aerospace
+MACOS_CONFIGS := nvim aerospace tmux
 
 # Directory-level symlinks (Linux only)
-LINUX_CONFIGS := nvim ubuntu_nvim
+LINUX_CONFIGS := nvim ubuntu_nvim tmux
 
 # Directory-level symlinks (Windows only)
 # Note: PowerShell profile path is special on Windows
@@ -299,9 +299,6 @@ link-linux: _ensure-xdg-config
 			FORCE=$(FORCE); \
 	done
 	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[File-level: fish]$(COLOR_RESET)"
-	$(Q)$(MAKE) _link-fish-files FORCE=$(FORCE)
-	$(ECHO) ""
 	$(ECHO) "$(COLOR_GREEN)Linux: Done$(COLOR_RESET)"
 
 # -----------------------------------------------------------------------------
@@ -325,9 +322,6 @@ link-windows: _ensure-xdg-config
 		SRC="$(CONFIG_DIR)/nvim" \
 		DEST="$(LOCALAPPDATA)/nvim" \
 		FORCE=$(FORCE)
-	$(ECHO) ""
-	$(ECHO) "$(COLOR_CYAN)[File-level: fish]$(COLOR_RESET)"
-	$(Q)$(MAKE) _link-fish-files FORCE=$(FORCE)
 	$(ECHO) ""
 	$(ECHO) "$(COLOR_GREEN)Windows: Done$(COLOR_RESET)"
 
@@ -360,7 +354,6 @@ unlink-linux:
 	$(Q)for config in $(COMMON_CONFIGS) $(LINUX_CONFIGS); do \
 		$(MAKE) _remove-link DEST="$(XDG_CONFIG_HOME)/$$config"; \
 	done
-	$(Q)$(MAKE) _unlink-fish-files
 	$(ECHO) "$(COLOR_GREEN)Linux: Unlink complete$(COLOR_RESET)"
 
 unlink-windows:
@@ -369,7 +362,6 @@ unlink-windows:
 		$(MAKE) _remove-link DEST="$(XDG_CONFIG_HOME)/$$config"; \
 	done
 	$(Q)$(MAKE) _remove-link DEST="$(LOCALAPPDATA)/nvim"
-	$(Q)$(MAKE) _unlink-fish-files
 	$(ECHO) "$(COLOR_GREEN)Windows: Unlink complete$(COLOR_RESET)"
 
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ make unlink    # リンクを削除
 
 | 設定 | パス | 対象OS |
 |------|------|--------|
-| Neovim | `~/.config/nvim` | 全OS |
+| Neovim | `~/.config/nvim` (Windows: `$LOCALAPPDATA/nvim`) | macOS / Linux / Windows |
 | WezTerm | `~/.config/wezterm` | 全OS |
 | fish | `~/.config/fish` | 全OS |
 | tmux | `~/.config/tmux` | 全OS |
 | AeroSpace | `~/.config/aerospace` | macOS |
 | Karabiner | `~/.config/karabiner` | macOS |
+| PowerShell | `~/.config/powershell` | Windows |
 | ubuntu_nvim | `~/.config/ubuntu_nvim` | Linux |
 
 ## ディレクトリ構成
@@ -80,5 +81,6 @@ dotfiles/
     ├── tmux/         # tmux 設定
     ├── aerospace/    # AeroSpace 設定 (macOS)
     ├── karabiner/    # Karabiner 設定 (macOS)
+    ├── powershell/   # PowerShell 設定 (Windows)
     └── ubuntu_nvim/  # Ubuntu用 Neovim 設定
 ```

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ make unlink    # リンクを削除
 |------|------|--------|
 | Neovim | `~/.config/nvim` (Windows: `$LOCALAPPDATA/nvim`) | macOS / Linux / Windows |
 | WezTerm | `~/.config/wezterm` | 全OS |
-| fish | `~/.config/fish` | 全OS |
-| tmux | `~/.config/tmux` | 全OS |
+| fish | `~/.config/fish` | macOS |
+| tmux | `~/.config/tmux` | macOS / Linux |
 | AeroSpace | `~/.config/aerospace` | macOS |
 | Karabiner | `~/.config/karabiner` | macOS |
 | PowerShell | `~/.config/powershell` | Windows |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,84 @@
 # dotfiles
-This repository is used to manage dotfiles.
+
+個人用の設定ファイル管理リポジトリです。
+
+## 前提条件
+
+### macOS
+
+```bash
+# Xcode Command Line Tools をインストール（make が含まれる）
+xcode-select --install
+```
+
+### Linux (Ubuntu/Debian)
+
+```bash
+sudo apt install make
+```
+
+### Windows
+
+以下のいずれかの方法で `make` を使えるようにしてください。
+
+**方法1: Scoop（推奨）**
+```powershell
+scoop install make
+```
+
+**方法2: Chocolatey**
+```powershell
+choco install make
+```
+
+**方法3: Git Bash / WSL を使う**
+Git Bash または WSL 内で実行すれば `make` が使えます。
+
+## 使い方
+
+### シンボリックリンクの作成
+
+```bash
+# OS を自動判定してリンク作成
+make link
+
+# 既存ファイルがある場合は強制上書き
+make link FORCE=1
+```
+
+### その他のコマンド
+
+```bash
+make help      # ヘルプ表示
+make status    # 現在のリンク状態を確認
+make check     # OS検出結果を確認
+make unlink    # リンクを削除
+```
+
+## 管理対象
+
+| 設定 | パス | 対象OS |
+|------|------|--------|
+| Neovim | `~/.config/nvim` | 全OS |
+| WezTerm | `~/.config/wezterm` | 全OS |
+| fish | `~/.config/fish` | 全OS |
+| tmux | `~/.config/tmux` | 全OS |
+| AeroSpace | `~/.config/aerospace` | macOS |
+| Karabiner | `~/.config/karabiner` | macOS |
+| ubuntu_nvim | `~/.config/ubuntu_nvim` | Linux |
+
+## ディレクトリ構成
+
+```
+dotfiles/
+├── Makefile          # シンボリックリンク管理
+├── README.md
+└── config/
+    ├── nvim/         # Neovim 設定
+    ├── wezterm/      # WezTerm 設定
+    ├── fish/         # fish shell 設定
+    ├── tmux/         # tmux 設定
+    ├── aerospace/    # AeroSpace 設定 (macOS)
+    ├── karabiner/    # Karabiner 設定 (macOS)
+    └── ubuntu_nvim/  # Ubuntu用 Neovim 設定
+```

--- a/config/wezterm/keybinds_common.lua
+++ b/config/wezterm/keybinds_common.lua
@@ -147,7 +147,7 @@ return {
 			-- パネル位置入れ替え
 			{ key = "r", action = act.RotatePanes("Clockwise") }, -- 時計回りに回転
 			{ key = "R", action = act.RotatePanes("CounterClockwise") }, -- 反時計回りに回転
-			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus" }) }, -- 選択してスワップ
+			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus", alphabet = "1234567890" }) }, -- 選択してスワップ
 
 			-- フォントサイズ調整 (=/-/0)
 			{ key = "=", action = act.IncreaseFontSize },

--- a/config/wezterm/keybinds_common.lua
+++ b/config/wezterm/keybinds_common.lua
@@ -19,7 +19,7 @@ wezterm.on("update-right-status", function(window, pane)
 	local name = window:active_key_table()
 	if name then
 		local display_names = {
-			adjust_mode = "ADJUST (hjkl:pane, =-0:font)",
+			adjust_mode = "ADJUST (hjkl:size, HJKL:swap, =-0:font)",
 			activate_pane = "PANE SELECT",
 			copy_mode = "COPY",
 		}
@@ -136,13 +136,19 @@ return {
 	-- キーテーブル
 	-- https://wezfurlong.org/wezterm/config/key-tables.html
 	key_tables = {
-		-- 調整モード（パネルサイズ + フォントサイズ） leader + s
+		-- 調整モード（パネルサイズ + フォントサイズ + パネル入れ替え） leader + s
 		adjust_mode = {
 			-- パネルサイズ調整 (hjkl)
 			{ key = "h", action = act.AdjustPaneSize({ "Left", 1 }) },
 			{ key = "l", action = act.AdjustPaneSize({ "Right", 1 }) },
 			{ key = "k", action = act.AdjustPaneSize({ "Up", 1 }) },
 			{ key = "j", action = act.AdjustPaneSize({ "Down", 1 }) },
+
+			-- パネル位置入れ替え (HJKL)
+			{ key = "H", action = act.SwapActivePaneDirection("Left") },
+			{ key = "L", action = act.SwapActivePaneDirection("Right") },
+			{ key = "K", action = act.SwapActivePaneDirection("Up") },
+			{ key = "J", action = act.SwapActivePaneDirection("Down") },
 
 			-- フォントサイズ調整 (=/-/0)
 			{ key = "=", action = act.IncreaseFontSize },

--- a/config/wezterm/keybinds_common.lua
+++ b/config/wezterm/keybinds_common.lua
@@ -147,7 +147,7 @@ return {
 			-- パネル位置入れ替え
 			{ key = "r", action = act.RotatePanes("Clockwise") }, -- 時計回りに回転
 			{ key = "R", action = act.RotatePanes("CounterClockwise") }, -- 反時計回りに回転
-			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus", alphabet = "1234567890" }) }, -- 選択してスワップ
+			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus", alphabet = "123456789" }) }, -- 選択してスワップ
 
 			-- フォントサイズ調整 (=/-/0)
 			{ key = "=", action = act.IncreaseFontSize },

--- a/config/wezterm/keybinds_common.lua
+++ b/config/wezterm/keybinds_common.lua
@@ -19,7 +19,7 @@ wezterm.on("update-right-status", function(window, pane)
 	local name = window:active_key_table()
 	if name then
 		local display_names = {
-			adjust_mode = "ADJUST (hjkl:size, HJKL:swap, =-0:font)",
+			adjust_mode = "ADJUST (hjkl:size, r/R:rotate, s:swap, =-0:font)",
 			activate_pane = "PANE SELECT",
 			copy_mode = "COPY",
 		}
@@ -144,11 +144,10 @@ return {
 			{ key = "k", action = act.AdjustPaneSize({ "Up", 1 }) },
 			{ key = "j", action = act.AdjustPaneSize({ "Down", 1 }) },
 
-			-- パネル位置入れ替え (HJKL)
-			{ key = "H", action = act.SwapActivePaneDirection("Left") },
-			{ key = "L", action = act.SwapActivePaneDirection("Right") },
-			{ key = "K", action = act.SwapActivePaneDirection("Up") },
-			{ key = "J", action = act.SwapActivePaneDirection("Down") },
+			-- パネル位置入れ替え
+			{ key = "r", action = act.RotatePanes("Clockwise") }, -- 時計回りに回転
+			{ key = "R", action = act.RotatePanes("CounterClockwise") }, -- 反時計回りに回転
+			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus" }) }, -- 選択してスワップ
 
 			-- フォントサイズ調整 (=/-/0)
 			{ key = "=", action = act.IncreaseFontSize },


### PR DESCRIPTION
Implement OS-aware (macOS/Linux/Windows) symlink orchestration with:
- Idempotent link creation (remove existing links before creating)
- Safety checks for existing files/directories (FORCE=1 to override)
- Per-OS config targets (aerospace/karabiner for macOS, ubuntu_nvim for Linux)
- Helpful commands: make link, make unlink, make status, make help