### PR TITLE
feat(wezterm): Add panel swap feature to WezTerm adjustment mode

### DIFF
--- a/config/wezterm/keybinds_common.lua
+++ b/config/wezterm/keybinds_common.lua
@@ -147,7 +147,7 @@ return {
 			-- パネル位置入れ替え
 			{ key = "r", action = act.RotatePanes("Clockwise") }, -- 時計回りに回転
 			{ key = "R", action = act.RotatePanes("CounterClockwise") }, -- 反時計回りに回転
-			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus" }) }, -- 選択してスワップ
+			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus", alphabet = "1234567890" }) }, -- 選択してスワップ
 
 			-- フォントサイズ調整 (=/-/0)
 			{ key = "=", action = act.IncreaseFontSize },

--- a/config/wezterm/keybinds_common.lua
+++ b/config/wezterm/keybinds_common.lua
@@ -19,7 +19,7 @@ wezterm.on("update-right-status", function(window, pane)
 	local name = window:active_key_table()
 	if name then
 		local display_names = {
-			adjust_mode = "ADJUST (hjkl:pane, =-0:font)",
+			adjust_mode = "ADJUST (hjkl:size, HJKL:swap, =-0:font)",
 			activate_pane = "PANE SELECT",
 			copy_mode = "COPY",
 		}
@@ -136,13 +136,19 @@ return {
 	-- キーテーブル
 	-- https://wezfurlong.org/wezterm/config/key-tables.html
 	key_tables = {
-		-- 調整モード（パネルサイズ + フォントサイズ） leader + s
+		-- 調整モード（パネルサイズ + フォントサイズ + パネル入れ替え） leader + s
 		adjust_mode = {
 			-- パネルサイズ調整 (hjkl)
 			{ key = "h", action = act.AdjustPaneSize({ "Left", 1 }) },
 			{ key = "l", action = act.AdjustPaneSize({ "Right", 1 }) },
 			{ key = "k", action = act.AdjustPaneSize({ "Up", 1 }) },
 			{ key = "j", action = act.AdjustPaneSize({ "Down", 1 }) },
+
+			-- パネル位置入れ替え (HJKL)
+			{ key = "H", action = act.SwapActivePaneDirection("Left") },
+			{ key = "L", action = act.SwapActivePaneDirection("Right") },
+			{ key = "K", action = act.SwapActivePaneDirection("Up") },
+			{ key = "J", action = act.SwapActivePaneDirection("Down") },
 
 			-- フォントサイズ調整 (=/-/0)
 			{ key = "=", action = act.IncreaseFontSize },

--- a/config/wezterm/keybinds_common.lua
+++ b/config/wezterm/keybinds_common.lua
@@ -147,7 +147,7 @@ return {
 			-- パネル位置入れ替え
 			{ key = "r", action = act.RotatePanes("Clockwise") }, -- 時計回りに回転
 			{ key = "R", action = act.RotatePanes("CounterClockwise") }, -- 反時計回りに回転
-			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus", alphabet = "1234567890" }) }, -- 選択してスワップ
+			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus", alphabet = "123456789" }) }, -- 選択してスワップ
 
 			-- フォントサイズ調整 (=/-/0)
 			{ key = "=", action = act.IncreaseFontSize },

--- a/config/wezterm/keybinds_common.lua
+++ b/config/wezterm/keybinds_common.lua
@@ -19,7 +19,7 @@ wezterm.on("update-right-status", function(window, pane)
 	local name = window:active_key_table()
 	if name then
 		local display_names = {
-			adjust_mode = "ADJUST (hjkl:size, HJKL:swap, =-0:font)",
+			adjust_mode = "ADJUST (hjkl:size, r/R:rotate, s:swap, =-0:font)",
 			activate_pane = "PANE SELECT",
 			copy_mode = "COPY",
 		}
@@ -144,11 +144,10 @@ return {
 			{ key = "k", action = act.AdjustPaneSize({ "Up", 1 }) },
 			{ key = "j", action = act.AdjustPaneSize({ "Down", 1 }) },
 
-			-- パネル位置入れ替え (HJKL)
-			{ key = "H", action = act.SwapActivePaneDirection("Left") },
-			{ key = "L", action = act.SwapActivePaneDirection("Right") },
-			{ key = "K", action = act.SwapActivePaneDirection("Up") },
-			{ key = "J", action = act.SwapActivePaneDirection("Down") },
+			-- パネル位置入れ替え
+			{ key = "r", action = act.RotatePanes("Clockwise") }, -- 時計回りに回転
+			{ key = "R", action = act.RotatePanes("CounterClockwise") }, -- 反時計回りに回転
+			{ key = "s", action = act.PaneSelect({ mode = "SwapWithActiveKeepFocus" }) }, -- 選択してスワップ
 
 			-- フォントサイズ調整 (=/-/0)
 			{ key = "=", action = act.IncreaseFontSize },


### PR DESCRIPTION
leader+s の調整モード中に Shift+hjkl (HJKL) でアクティブパネルと
隣接パネルの位置を交換できるようにした。
- H: 左のパネルと入れ替え
- L: 右のパネルと入れ替え
- K: 上のパネルと入れ替え
- J: 下のパネルと入れ替え