### PR TITLE
Follow-up: document AutoHotkey as Windows managed target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ config/
 - 全OS共通: wezterm
 - macOS: nvim, aerospace, tmux, fish (ファイルレベル), karabiner (ファイルレベル)
 - Linux: nvim, ubuntu_nvim, tmux
-- Windows: powershell, nvim（$LOCALAPPDATA/nvim）
+- Windows: powershell, autohotkey, nvim（$LOCALAPPDATA/nvim）
 
 **Neovim内のOS分岐**:
 - `lua/config/macos.lua` - macOS固有設定

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ make unlink    # リンクを削除
 | AeroSpace | `~/.config/aerospace` | macOS |
 | Karabiner | `~/.config/karabiner` | macOS |
 | PowerShell | `~/.config/powershell` | Windows |
+| AutoHotkey | `~/.config/autohotkey` | Windows |
 | ubuntu_nvim | `~/.config/ubuntu_nvim` | Linux |
 
 ## ディレクトリ構成
@@ -82,5 +83,6 @@ dotfiles/
     ├── aerospace/    # AeroSpace 設定 (macOS)
     ├── karabiner/    # Karabiner 設定 (macOS)
     ├── powershell/   # PowerShell 設定 (Windows)
+    ├── autohotkey/   # AutoHotkey 設定 (Windows)
     └── ubuntu_nvim/  # Ubuntu用 Neovim 設定
 ```


### PR DESCRIPTION
### Motivation
- The `Makefile` includes `WINDOWS_CONFIGS := powershell autohotkey` but docs omitted `autohotkey`, creating a documentation/runtime mismatch that can cause missed reviews when `config/autohotkey/` changes.

### Description
- Added `autohotkey` to the Windows managed targets in `CLAUDE.md` and added an `AutoHotkey` entry and `config/autohotkey/` directory line to `README.md` to align docs with `Makefile` behavior.

### Testing
- Verified references with `rg` across `Makefile`, `README.md`, and `CLAUDE.md` and committed the documentation updates with `git commit`, both of which succeeded; a network lookup attempt failed due to environment restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41c58562c8320980059dff4a69863)