### PR TITLE
[codex] add make test workflow

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -1,0 +1,51 @@
+name: make-test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  linux-make:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare isolated home
+        run: |
+          test_root="$(mktemp -d)"
+          mkdir -p "$test_root/home"
+          echo "HOME=$test_root/home" >> "$GITHUB_ENV"
+          echo "XDG_CONFIG_HOME=$test_root/home/.config" >> "$GITHUB_ENV"
+
+      - name: Check detected OS
+        run: make check
+
+      - name: Check initial status
+        run: make status
+
+      - name: Create Linux symlinks
+        run: make link-linux
+
+      - name: Verify Linux symlinks
+        run: |
+          for config in wezterm nvim ubuntu_nvim tmux; do
+            test -L "$XDG_CONFIG_HOME/$config"
+          done
+
+      - name: Check linked status
+        run: make status
+
+      - name: Remove Linux symlinks
+        run: make unlink-linux
+
+      - name: Verify Linux symlinks removed
+        run: |
+          for config in wezterm nvim ubuntu_nvim tmux; do
+            test ! -L "$XDG_CONFIG_HOME/$config"
+          done

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -14,7 +14,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare isolated home
         run: |


### PR DESCRIPTION
## 概要
- Linux 向けの `make` スモークテストを実行する GitHub Actions workflow を追加
- 隔離した `HOME` / `XDG_CONFIG_HOME` を使い、実環境を汚さずに `make` のリンク処理を検証

## 変更内容
- `.github/workflows/make-test.yml` を追加
- `make check`
- `make status`
- `make link-linux`
- Linux 対象のシンボリックリンク生成確認
- `make unlink-linux`
- Linux 対象のシンボリックリンク削除確認

## 検証
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/make-test.yml"); puts "YAML OK"'`
- 隔離した一時ディレクトリ配下で workflow 相当の `make` スモークテストを実行