### PR TITLE
[codex] slim agent docs and split shared guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,107 +1,19 @@
-# Dotfiles Repository Guidelines
+# GitHub Copilot Instructions
 
-## Structure and Module Organization
+Shared repository rules live in `docs/agent-guides/`. Keep this file short and use it as an entrypoint only.
 
-This dotfiles repository shares `~/.config` configurations across macOS, Linux, and Windows. Keep OS-specific logic confined to dedicated files/directories.
+## Read First
 
-- **fish/** - Shell abbreviations ([abbr.fish](../config/fish/abbr.fish)) and functions ([functions/](../config/fish/functions/))
-  - `clip.fish`, `yazi.fish` contain macOS-specific features
-- **nvim/** - LazyVim-based. Core config in [lua/config/](../config/nvim/lua/config/), plugins in [lua/plugins/](../config/nvim/lua/plugins/)
-  - [lazy.lua](../config/nvim/lua/config/lazy.lua) imports LazyVim extras
-- **wezterm/** - OS detection with branching ([wezterm.lua](../config/wezterm/wezterm.lua))
-  - Common binds in [keybinds_common.lua](../config/wezterm/keybinds_common.lua), OS-specific in `keybinds_mac.lua`/`keybinds_win.lua`
-- **karabiner/** - macOS keymaps ([numpad.json](../config/karabiner/numpad.json))
-- **powershell/** - Windows-only ([user_profile.ps1](../config/powershell/user_profile.ps1))
-- **tmux/** - [tmux.conf](../config/tmux/tmux.conf)
-- **ubuntu_nvim/** - Lightweight Vim alternative ([init.vim](../config/ubuntu_nvim/init.vim))
+- `docs/agent-guides/core.md`
+- `docs/agent-guides/validation.md`
+- `docs/agent-guides/components.md`
+- `config/AGENTS.md` for changes under `config/`
 
-## Development Commands
+## Working Rules
 
-### Neovim
-```bash
-# Sync plugins
-nvim --headless "+Lazy sync" +qa
-
-# Format Lua files
-stylua --config nvim/stylua.toml nvim/lua/**/*.lua
-
-# Health check
-nvim --headless "+checkhealth" +qa
-```
-
-### Fish
-```bash
-# Format functions
-fish_indent --write fish/functions/*.fish
-
-# Check formatting
-fish -c "for f in fish/functions/*.fish; fish_indent --check $f; end"
-```
-
-### WezTerm
-```bash
-# Smoke test
-wezterm --config-file wezterm/wezterm.lua start --always-new-process
-
-# Test module loading in REPL
-wezterm -n --config-file wezterm/wezterm.lua
-# > local m = require "keybinds_mac"
-```
-
-### Other
-```bash
-# Validate Karabiner JSON
-jq empty karabiner/numpad.json
-
-# Reload tmux config
-tmux source-file ~/.config/tmux/tmux.conf
-```
-
-## Coding Patterns
-
-### Lua (Neovim)
-- **Indentation**: 2 spaces, auto-formatted with stylua
-- **Module naming**: lowercase + underscore (`editor.lua`, `keybinds_mac.lua`)
-- **Plugin definitions**: Split into [lua/plugins/](../config/nvim/lua/config/lazy.lua), LazyVim extras imported in `lazy.lua`
-  ```lua
-  { import = "lazyvim.plugins.extras.ai.copilot" },
-  { import = "plugins" }, -- Custom plugins
-  ```
-
-### Fish
-- **Function naming**: `snake_case`
-- **Abbreviations**: Consolidated in [abbr.fish](../config/fish/abbr.fish) (`gs`, `ga`, `ll`, etc.)
-- **Loading**: Declarative from `conf.d`, or `source` in [config.fish](../config/fish/config.fish)
-
-### WezTerm (Lua)
-- **OS branching**: Detect via `wezterm.target_triple` (`apple`, `windows`, `linux`)
-- **Keybind merging**: Load common keys first, append OS-specific with `ipairs`
-  ```lua
-  for _, key in ipairs(os_binds.keys or {}) do
-    table.insert(keybinds.keys, key)
-  end
-  ```
-
-### JSON
-- **Trailing newline**: Required
-- **Key order**: Alphabetical preferred
-- **Quotes**: Double only
-
-## Cross-Platform Support
-
-- **No absolute paths**: Use environment variables (`$XDG_CONFIG_HOME`, `~`)
-- **OS-specific logic**: Localize to existing files/directories
-  - Neovim: [lua/config/macos.lua](../config/nvim/lua/config/macos.lua), [windows.lua](../config/nvim/lua/config/windows.lua), [wsl.lua](../config/nvim/lua/config/wsl.lua)
-  - WezTerm: `keybinds_mac.lua`, `keybinds_win.lua`
-
-## Commit Conventions
-
-- **Format**: Conventional Commits (`feat:`, `fix:`, `chore:`)
-- **Granularity**: 1 logical change = 1 commit
-- **Visual changes**: Include screenshots
-- **Manual steps**: Document in PR if needed (e.g., re-run `nvim --headless "+Lazy sync"`)
-
-## Security
-
-- **Secrets**: Never commit host-specific tokens or SSH information
-- **Overrides**: Keep host-specific configs outside version control
+- Confirm the target OS and target directory before editing.
+- Keep OS-specific logic isolated to existing files or directories.
+- Preserve idempotent link behavior managed by `Makefile`.
+- Run validation commands that match the changed paths.
+- If `Makefile` or link definitions change, run `make check` and `make status`.
+- Use Conventional Commits and document validation in the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,292 +1,38 @@
 # AGENTS.md
 
-このファイルは、このリポジトリで作業するエージェント向けの実行手順書です。
-説明よりも、実際の作業指示を優先してください。
-
-## 0. 基本方針
-
-- 変更前に、対象OSと変更対象ディレクトリを明確化する。
-- 1つの変更で目的を1つに絞る。
-- 既存の設計（OS分離・idempotent）を崩さない。
-- 既存ファイルを壊さないため、検証コマンドを必ず実行する。
-- 変更理由をコミットメッセージとPR本文に明記する。
-
-## 1. リポジトリ概要
-
-- このリポジトリは macOS / Linux / Windows 対応の dotfiles 管理。
-- 管理の中心は `Makefile` のシンボリックリンク処理。
-- 主要ディレクトリ:
-  - `config/nvim/` : Neovim 設定（LazyVimベース）
-  - `config/wezterm/` : WezTerm 設定
-  - `config/fish/` : Fish 設定（主に macOS）
-  - `config/tmux/` : Tmux 設定（macOS/Linux）
-  - `config/aerospace/` : AeroSpace 設定（macOS）
-  - `config/karabiner/` : Karabiner 設定（macOS）
-  - `config/powershell/` : PowerShell 設定（Windows）
-  - `config/ubuntu_nvim/` : Ubuntu向け Vim 設定（レガシー）
-
-## 2. 作業開始チェック
-
-- 現在ブランチ確認:
-  - `git branch --show-current`
-- 差分確認:
-  - `git status --short`
-- 変更ファイルの位置確認:
-  - `rg --files config | head`
-- 変更対象が OS 固有かを先に判断する。
-
-## 3. リンク管理（Makefile）
-
-- OS自動判定でリンク作成:
-  - `make link`
-- 既存ファイルを強制上書き:
-  - `make link FORCE=1`
-- リンク状態確認:
-  - `make status`
-- リンク削除:
-  - `make unlink`
-- OS検出結果確認:
-  - `make check`
-
-実施ルール:
-
-- リンク定義を変更した場合は `make check` と `make status` を実行する。
-- 強制上書きはローカル検証時のみ使用し、実行理由をPRに記載する。
-- idempotent であること（2回実行しても破綻しないこと）を確認する。
-
-## 4. OS別の管理対象
-
-- 全OS共通:
-  - `wezterm`
-- macOS:
-  - `nvim`
-  - `aerospace`
-  - `tmux`
-  - `fish`（ファイルレベル）
-  - `karabiner`（ファイルレベル）
-- Linux:
-  - `nvim`
-  - `ubuntu_nvim`
-  - `tmux`
-- Windows:
-  - `powershell`
-  - `nvim`（`$LOCALAPPDATA/nvim`）
-
-運用ルール:
-
-- OS固有の変更は、対象外OSへ副作用を出さない。
-- 条件分岐は既存のOS判定パターンに合わせる。
-
-## 5. Neovim / Lua 変更ルール
-
-- インデントは 2 スペース。
-- 1行 120 文字以内を維持。
-- フォーマットは `stylua.toml` 設定に従う。
-- 命名は `snake_case` を使用。
-- OS分岐は専用ファイルへ分離する。
-
-OS分岐ファイル:
-
-- `lua/config/macos.lua`
-- `lua/config/windows.lua`
-- `lua/config/wsl.lua`
-
-推奨OS判定パターン（WezTerm/Lua）:
-
-```lua
-local is_mac = wezterm.target_triple:find("darwin")
-local is_windows = wezterm.target_triple:find("windows")
-```
-
-## 6. コンポーネント別の検証コマンド
-
-### 6.1 Neovim
-
-- プラグイン同期:
-  - `nvim --headless "+Lazy sync" +qa`
-- Luaフォーマット:
-  - `stylua --config config/nvim/stylua.toml config/nvim/lua/**/*.lua`
-- ヘルスチェック:
-  - `nvim --headless "+checkhealth" +qa`
-
-実施基準:
-
-- `config/nvim/` を変更したら、最低でもフォーマットとヘルスチェックを実行する。
-
-### 6.2 Fish
-
-- 整形:
-  - `fish_indent --write config/fish/functions/*.fish`
-
-実施基準:
-
-- `config/fish/functions/*.fish` を変更したら必ず実行する。
-
-### 6.3 Karabiner
-
-- JSON検証:
-  - `jq empty config/karabiner/numpad.json`
-
-実施基準:
-
-- `config/karabiner/*.json` を変更したら全対象ファイルに対して `jq empty` を実行する。
-
-### 6.4 WezTerm
-
-- 起動確認:
-  - `wezterm --config-file config/wezterm/wezterm.lua start --always-new-process`
-
-実施基準:
-
-- `config/wezterm/` を変更したら実行する。
-- GUI起動不可環境では、未実施理由を記録する。
-
-### 6.5 Tmux
-
-- 設定リロード:
-  - `tmux source-file ~/.config/tmux/tmux.conf`
-
-実施基準:
-
-- `config/tmux/` を変更したら実行する。
-- tmuxセッションがない場合は、未実施理由を記録する。
-
-## 7. レビュー観点（必須チェックリスト）
-
-- 変更が対象OSに限定されている。
-- 非対象OSの設定・リンクに影響していない。
-- Makefileの挙動がidempotent。
-- フォーマット済みである。
-- 構文エラーがない。
-- ハードコードされた秘密情報がない。
-- 既存命名規則（snake_case）に従っている。
-- 既存のディレクトリ責務を壊していない。
-
-## 8. セキュリティ
-
-- 認証情報・トークン・秘密鍵をコミットしない。
-- 機密情報は `.gitignore` 対象ファイルへ保存する。
-- サンプル値を使う場合は実運用値を置かない。
-
-## 9. 変更手順テンプレート
-
-1. `git status --short` で作業前の状態確認。
-2. 変更対象ファイルを編集。
-3. 対象コンポーネントの整形・検証を実行。
-4. Makefile またはリンク定義を変更した場合は `make check` と `make status` を実行。
-5. `git diff -- <path>` で差分確認。
-6. `git add <path>` で必要ファイルのみステージ。
-7. Conventional Commits 形式でコミット。
-8. PR本文に「変更内容 / 検証結果 / 既知の未実施項目」を記載。
-
-## 10. コミット規約
-
-- Conventional Commits を使用:
-  - `feat:`
-  - `fix:`
-  - `chore:`
-  - `refactor:`
-  - `docs:`
-- 件名は簡潔に 1 行で目的を示す。
-- 破壊的変更は本文で明示する。
-
-例:
-
-- `docs: add AGENTS.md from CLAUDE.md guidance`
-- `fix(wezterm): isolate mac keybind handling`
-- `refactor(nvim): split os-specific bootstrap logic`
-
-## 11. PR本文テンプレート
-
-- 概要:
-  - 何を、なぜ変更したかを 2〜4 行で記載。
-- 変更ファイル:
-  - 主要ファイルを箇条書き。
-- 検証:
-  - 実行コマンドと結果（成功/未実施理由）を列挙。
-- 影響範囲:
-  - OS別に影響有無を明記。
-- 懸念点:
-  - 未解決事項や追加確認が必要な点を列挙。
-
-## 12. Claude 固有情報の扱い
-
-- Claude 専用ディレクトリや専用メモリ機能を前提にしない。
-- 他エージェントで再現できない運用は、注記として扱う。
-- 本ドキュメントはツール非依存の実行手順のみを保持する。
-
-## 13. skills 化を検討する定型手順（提案）
-
-- `skill: dotfiles-validation`
-  - 変更パスに応じて検証コマンドを自動選択・実行。
-- `skill: os-impact-check`
-  - 変更差分からOS影響範囲を自動レビュー。
-- `skill: make-link-smoke-test`
-  - `make check/status/link` の反復テストを定型化。
-- `skill: commit-pr-writer`
-  - Conventional Commit とPRテンプレート生成を支援。
-
-## 14. 非機能要件
-
-- 手順は短い箇条書きを優先する。
-- 曖昧表現を使わない。
-- 例外がある場合は「条件」と「代替手順」を明記する。
-- 将来の自動化を想定し、コマンドをそのまま実行可能な形で記載する。
-
-## 15. 最低限の完了条件
-
-- 変更ファイルが意図通りである。
-- 対応する検証コマンドを実行済みである。
-- 未実施項目には理由が記録されている。
-- コミットメッセージが規約に準拠している。
-- PR本文に変更理由と検証結果が記載されている。
-
-## 16. Skills
-
-A skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of
-skills that can be used. Each entry includes a name, description, and file path so you can open the source for
-full instructions when using a specific skill.
-
-### Available skills
-
-- openai-docs: Use when the user asks how to build with OpenAI products or APIs and needs up-to-date official
-  documentation with citations, help choosing the latest model for a use case, or explicit GPT-5.4 upgrade and
-  prompt-upgrade guidance; prioritize OpenAI docs MCP tools, use bundled references only as helper context, and
-  restrict any fallback browsing to official OpenAI domains. (file:
-  `/Users/y_kashimura/.codex/skills/.system/openai-docs/SKILL.md`)
-- skill-creator: Guide for creating effective skills. This skill should be used when users want to create a new
-  skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows,
-  or tool integrations. (file: `/Users/y_kashimura/.codex/skills/.system/skill-creator/SKILL.md`)
-- skill-installer: Install Codex skills into `$CODEX_HOME/skills` from a curated list or a GitHub repo path. Use
-  when a user asks to list installable skills, install a curated skill, or install a skill from another repo
-  (including private repos). (file: `/Users/y_kashimura/.codex/skills/.system/skill-installer/SKILL.md`)
-
-### How to use skills
-
-- Discovery: The list above is the skills available in this session (name + description + file path). Skill
-  bodies live on disk at the listed paths.
-- Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a
-  skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all.
-  Do not carry skills across turns unless re-mentioned.
-- Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue
-  with the best fallback.
-- How to use a skill (progressive disclosure):
-  1. After deciding to use a skill, open its `SKILL.md`. Read only enough to follow the workflow.
-  2. When `SKILL.md` references relative paths (e.g., `scripts/foo.py`), resolve them relative to the skill
-     directory listed above first, and only consider other paths if needed.
-  3. If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the
-     request; don't bulk-load everything.
-  4. If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.
-  5. If `assets/` or templates exist, reuse them instead of recreating from scratch.
-- Coordination and sequencing:
-  - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use
-    them.
-  - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.
-- Context hygiene:
-  - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.
-  - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're
-    blocked.
-  - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that
-    choice.
-- Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the
-  issue, pick the next-best approach, and continue.
+このリポジトリのエージェント向け入口。詳細ルールの正本は `docs/agent-guides/` に置く。
+
+## 変更前に確認すること
+
+- 対象 OS と変更対象ディレクトリを明確化する。
+- `git branch --show-current`
+- `git status --short`
+- 変更が OS 固有か共通かを先に判断する。
+
+## 必須ルール
+
+- 1 つの変更で目的を 1 つに絞る。
+- OS 分離と idempotent を崩さない。
+- OS 固有変更は対象外 OS に副作用を出さない。
+- 変更したパスに対応する検証コマンドを必ず実行する。
+- `Makefile` やリンク定義を変えたら `make check` と `make status` を実行する。
+- 強制上書きは `make link FORCE=1` をローカル検証時だけで使い、理由を PR に書く。
+- 認証情報、トークン、秘密鍵をコミットしない。
+- Conventional Commits を使う。
+- PR に変更理由、検証結果、未実施項目を書く。
+
+## 参照先
+
+- 共通方針: `docs/agent-guides/core.md`
+- 検証コマンド: `docs/agent-guides/validation.md`
+- コンポーネント規約: `docs/agent-guides/components.md`
+- `config/` 配下の補足: `config/AGENTS.md`
+- Claude 向け入口: `CLAUDE.md`
+- GitHub Copilot 向け入口: `.github/copilot-instructions.md`
+
+## 対象ディレクトリ
+
+- 全 OS 共通: `config/wezterm/`
+- macOS: `config/nvim/` `config/aerospace/` `config/tmux/` `config/fish/` `config/karabiner/`
+- Linux: `config/nvim/` `config/ubuntu_nvim/` `config/tmux/`
+- Windows: `config/powershell/` `config/nvim/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,4 @@
 - 全 OS 共通: `config/wezterm/`
 - macOS: `config/nvim/` `config/aerospace/` `config/tmux/` `config/fish/` `config/karabiner/`
 - Linux: `config/nvim/` `config/ubuntu_nvim/` `config/tmux/`
-- Windows: `config/powershell/` `config/nvim/`
+- Windows: `config/powershell/` `config/autohotkey/` `config/nvim/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,97 +1,25 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file is a short entrypoint for Claude Code. Shared repository rules live in `docs/agent-guides/`.
 
-## Overview
+## Read First
 
-macOS/Linux/Windows対応のdotfiles管理リポジトリ。Makefileによるシンボリックリンク管理でidempotentな設計。
+- `docs/agent-guides/core.md`
+- `docs/agent-guides/validation.md`
+- `docs/agent-guides/components.md`
+- `config/AGENTS.md` when changing files under `config/`
 
-## Build & Development Commands
+## Repository Summary
 
-### Makefile Commands
-```bash
-make link              # OS自動判定でリンク作成
-make link FORCE=1      # 既存ファイルを強制上書き
-make status            # リンク状態確認
-make unlink            # リンク削除
-make check             # OS検出結果確認
-```
+- Cross-platform dotfiles for macOS, Linux, and Windows.
+- Link management is centered on `Makefile`.
+- Preserve OS separation and idempotent behavior.
 
-### Neovim
-```bash
-nvim --headless "+Lazy sync" +qa                      # プラグイン同期
-stylua --config config/nvim/stylua.toml config/nvim/lua/**/*.lua  # Luaフォーマット
-nvim --headless "+checkhealth" +qa                    # ヘルスチェック
-```
+## Required Workflow
 
-### Fish Shell
-```bash
-fish_indent --write config/fish/functions/*.fish
-```
-
-### Karabiner（JSON検証）
-```bash
-jq empty config/karabiner/numpad.json
-```
-
-### WezTerm（テスト起動）
-```bash
-wezterm --config-file config/wezterm/wezterm.lua start --always-new-process
-```
-
-### Tmux（設定リロード）
-```bash
-tmux source-file ~/.config/tmux/tmux.conf
-```
-
-## Architecture
-
-### Directory Structure
-```
-config/
-├── nvim/           # LazyVimベースのNeovim設定
-├── wezterm/        # WezTermターミナル設定
-├── fish/           # Fish shell設定（macOSのみ）
-├── tmux/           # Tmux設定（macOS/Linuxのみ）
-├── aerospace/      # macOSウィンドウマネージャー
-├── karabiner/      # macOSキーマップ
-├── powershell/     # Windows PowerShellプロファイル
-└── ubuntu_nvim/    # Ubuntu用Vim設定（レガシー）
-```
-
-### OS-Specific Configurations
-
-**Makefile内の管理対象**:
-- 全OS共通: wezterm
-- macOS: nvim, aerospace, tmux, fish (ファイルレベル), karabiner (ファイルレベル)
-- Linux: nvim, ubuntu_nvim, tmux
-- Windows: powershell, autohotkey, nvim（$LOCALAPPDATA/nvim）
-
-**Neovim内のOS分岐**:
-- `lua/config/macos.lua` - macOS固有設定
-- `lua/config/windows.lua` - Windows固有設定
-- `lua/config/wsl.lua` - WSL固有設定
-
-### Key Design Patterns
-
-1. **OS固有コードの分離**: 専用ファイルに集約（例: WezTermの`keybinds_mac.lua`/`keybinds_win.lua`）
-2. **ファイルレベルリンク**: fish/karabinerは環境依存ファイルを除外して個別リンク
-3. **Idempotent設計**: makeコマンドは複数回実行しても同じ結果
-
-## Coding Conventions
-
-### Lua (Neovim/WezTerm)
-- 2スペースインデント、120文字幅（stylua.toml準拠）
-- 命名規則: 小文字+アンダースコア（例: `my_function`）
-- 条件分岐パターン:
-```lua
-local is_mac = wezterm.target_triple:find("darwin")
-local is_windows = wezterm.target_triple:find("windows")
-```
-
-### Git Commits
-Conventional Commits形式: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`
-
-### Security
-- 環境変数やシークレットは`.gitignore`対象ファイルに記載
-- ハードコードされた認証情報を含めない
+- Confirm target OS and target directory before editing.
+- Run `git branch --show-current` and `git status --short` before changes.
+- Run validation commands for the changed paths.
+- If `Makefile` or link definitions change, run `make check` and `make status`.
+- Use Conventional Commits.
+- Record reason, validation, and any skipped checks in the PR.

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -15,5 +15,5 @@
 - `fish/`: 主に macOS
 - `tmux/`: macOS / Linux
 - `aerospace/` `karabiner/`: macOS
-- `powershell/`: Windows
+- `powershell/` `autohotkey/`: Windows
 - `ubuntu_nvim/`: Linux 向けレガシー Vim

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -1,57 +1,19 @@
-# Repository Guidelines
+# Config Subtree Guide
 
-## プロジェクト構成とモジュール整理
+このディレクトリは実際の設定資産を置く。共通ルールは `../docs/agent-guides/` を正本とする。
 
-このリポジトリは `~/.config` 以下の設定資産を macOS・Linux・Windows で共有するためのものです。
+## この配下で特に守ること
 
-OS 固有の変更は既存の専用ディレクトリに 閉じ込めてください。
+- OS 固有変更は既存の専用ディレクトリか専用ファイルに閉じ込める。
+- 既存のディレクトリ責務を壊さない。
+- 検証コマンドは `../docs/agent-guides/validation.md` に従う。
 
-主な構成は、シェル略称や起動スクリプトをまとめた `fish/`、 LazyVim ベースの Lua モジュールを置く `nvim/` （コア設定は `lua/config`、プラグイン定義は `lua/plugins`、 整形ルールは `stylua.toml`）、 OS ごとのキーバインドを分けた `wezterm/`、 macOS のキーマップを扱う `karabiner/numpad.json`、 Windows 用プロファイルの `powershell/user_profile.ps1`、 tmux 設定の `tmux/tmux.conf`、 そして軽量な Vim 代替の `ubuntu_nvim/` です。
+## 主要ディレクトリ
 
-## ビルド・テスト・開発コマンド
-
-プラグイン宣言を編集したら `nvim --headless "+Lazy sync" +qa` を実行しロックファイルを更新します。
-
-Lua モジュールは `stylua --config nvim/stylua.toml nvim/lua/**/*.lua` で整形してください。
-
-Fish スクリプトは `fish_indent --write fish/functions/*.fish` で整えます。
-
-Karabiner 設定は同期前に `jq empty karabiner/numpad.json` で構文検証します。
-
-wezterm の調整後は `wezterm --config-file wezterm/wezterm.lua start --always-new-process` でスモークテストを行います。
-
-## コーディングスタイルと命名規則
-
-Lua は 2 スペースインデントとし、 `stylua` が期待する順序規則に従います。
-モジュール名は小文字＋アンダースコアで統一します （例: `lua/plugins/editor.lua`）。
-
-Fish 関数は `snake_case` を維持し、 `conf.d` から宣言的に読み込ませます。
-
-tmux オプションは機能ごとにまとまりを持たせ、 非デフォルトの理由を示すコメントは最小限に留めます。
-
-JSON は終端改行を保ち、 可能ならキーをアルファベット順に整列させ、 ダブルクォートを使用します。
-
-## テストと検証
-
-Neovim 設定を変更したら `nvim --headless "+checkhealth" +qa` でプラグインやプロバイダの状態を確認します。
-
-Fish の更新前には `fish -c "for f in fish/functions/*.fish; fish_indent --check $f; end"` を走らせて整形崩れを検知します。
-
-wezterm の変更は `wezterm -n --config-file wezterm/wezterm.lua` から REPL を起動します。
-
-`require "keybinds_mac"` などで 各モジュールが読み込めるか確認します。
-
-tmux は稼働中のセッションで `tmux source-file ~/.config/tmux/tmux.conf` を実行し、リロードできるかテストしてください。
-
-## コミットとプルリクエストの指針
-
-Git ログが示す Conventional Commits （`feat: ...`、`fix: ...`、`chore: ...`）を踏襲し、 件名は簡潔にまとめます。
-1 つの論理変更ごとにコミットを分けると 同期スクリプトが扱いやすくなります。
-プルリクエストでは動機、 影響するディレクトリ、 必要な手動手順 （例: `nvim --headless "+Lazy sync"` の再実行） を記載してください。
-
-テーマやキーバインドなど視覚変更がある場合は スクリーンショットを添えます。 関連 Issue とのリンクと、 クロスプラットフォームへの影響有無も明記しましょう。
-
-## セキュリティと設定のヒント
-
-ホスト固有のシークレットやトークン、 SSH 情報は絶対にコミットせず、 バージョン管理外にホストごとのオーバーライドを 保持します。
-新しいツールを追加する際は `$XDG_CONFIG_HOME` に対応しているかを確認し、 絶対パスのハードコードより 環境変数を優先してください。
+- `nvim/`: LazyVim ベース
+- `wezterm/`: 全 OS 共通の端末設定
+- `fish/`: 主に macOS
+- `tmux/`: macOS / Linux
+- `aerospace/` `karabiner/`: macOS
+- `powershell/`: Windows
+- `ubuntu_nvim/`: Linux 向けレガシー Vim

--- a/docs/agent-guides/components.md
+++ b/docs/agent-guides/components.md
@@ -1,0 +1,36 @@
+# Agent Guide: Component Rules
+
+## Neovim / Lua
+
+- 2 スペースインデント。
+- 1 行 120 文字以内。
+- `stylua.toml` に従う。
+- 命名は `snake_case`。
+- OS 分岐は専用ファイルへ分離する。
+- OS 分岐ファイルは `config/nvim/lua/config/macos.lua` `windows.lua` `wsl.lua` を使う。
+
+## WezTerm / Lua
+
+- OS 判定は既存パターンに合わせる。
+
+```lua
+local is_mac = wezterm.target_triple:find("darwin")
+local is_windows = wezterm.target_triple:find("windows")
+```
+
+## Fish
+
+- 関数名は `snake_case`。
+- 環境依存ロジックは既存ファイル責務を崩さずに閉じ込める。
+
+## JSON
+
+- ダブルクォートを使う。
+- 終端改行を維持する。
+
+## Commit / PR
+
+- Conventional Commits を使う。`feat:` `fix:` `chore:` `refactor:` `docs:`
+- 件名は 1 行で目的を示す。
+- 破壊的変更は本文で明示する。
+- PR には概要、主要ファイル、検証結果、OS 影響、懸念点を書く。

--- a/docs/agent-guides/core.md
+++ b/docs/agent-guides/core.md
@@ -1,0 +1,48 @@
+# Agent Guide: Core Rules
+
+このディレクトリをエージェント向け正本とする。`AGENTS.md` `CLAUDE.md` `.github/copilot-instructions.md` は入口だけを持つ。
+
+## Scope
+
+- 対象は macOS / Linux / Windows 対応の dotfiles 管理。
+- 管理の中心は `Makefile` のシンボリックリンク処理。
+- 変更前に対象 OS と変更対象ディレクトリを明確化する。
+
+## Non-Negotiables
+
+- 1 つの変更で目的を 1 つに絞る。
+- 既存の設計方針である OS 分離と idempotent を崩さない。
+- OS 固有変更は対象外 OS に副作用を出さない。
+- 既存ファイルを壊さないため、対応する検証コマンドを必ず実行する。
+- 認証情報、トークン、秘密鍵をコミットしない。
+- 変更理由をコミットメッセージと PR 本文に明記する。
+
+## Start Checklist
+
+- `git branch --show-current`
+- `git status --short`
+- 変更対象が `config/` 配下のどこかを確認する。
+- 変更が OS 固有か共通かを先に判断する。
+
+## Makefile Rules
+
+- リンク管理コマンドは `make link` `make link FORCE=1` `make status` `make unlink` `make check` を使う。
+- リンク定義を変更した場合は `make check` と `make status` を実行する。
+- 強制上書きはローカル検証時のみ使い、理由を PR に書く。
+- idempotent 確認が必要な変更では同じコマンドを 2 回実行して破綻しないことを確認する。
+
+## OS Ownership
+
+- 全 OS 共通: `config/wezterm/`
+- macOS: `config/nvim/` `config/aerospace/` `config/tmux/` `config/fish/` `config/karabiner/`
+- Linux: `config/nvim/` `config/ubuntu_nvim/` `config/tmux/`
+- Windows: `config/powershell/` `config/nvim/`
+
+## Review And Finish
+
+- フォーマット済みで構文エラーがない。
+- 既存命名規則を壊していない。
+- 既存ディレクトリ責務を壊していない。
+- `git diff -- <path>` で意図した差分だけを確認する。
+- Conventional Commits を使う。
+- PR には「変更内容 / 検証結果 / 未実施項目」を書く。

--- a/docs/agent-guides/core.md
+++ b/docs/agent-guides/core.md
@@ -36,7 +36,7 @@
 - 全 OS 共通: `config/wezterm/`
 - macOS: `config/nvim/` `config/aerospace/` `config/tmux/` `config/fish/` `config/karabiner/`
 - Linux: `config/nvim/` `config/ubuntu_nvim/` `config/tmux/`
-- Windows: `config/powershell/` `config/nvim/`
+- Windows: `config/powershell/` `config/autohotkey/` `config/nvim/`
 
 ## Review And Finish
 

--- a/docs/agent-guides/validation.md
+++ b/docs/agent-guides/validation.md
@@ -1,0 +1,42 @@
+# Agent Guide: Validation
+
+変更したパスに応じて次を実行する。未実施なら理由を記録する。
+
+## Always
+
+- 作業前: `git status --short`
+- 差分確認: `git diff -- <path>`
+
+## Link Management
+
+- リンク定義や `Makefile` を変更したら `make check`
+- 同上で `make status`
+
+## Neovim
+
+- 対象: `config/nvim/`
+- 整形: `stylua --config config/nvim/stylua.toml config/nvim/lua/**/*.lua`
+- ヘルスチェック: `nvim --headless "+checkhealth" +qa`
+- 必要時の同期: `nvim --headless "+Lazy sync" +qa`
+
+## Fish
+
+- 対象: `config/fish/functions/*.fish`
+- 整形: `fish_indent --write config/fish/functions/*.fish`
+
+## Karabiner
+
+- 対象: `config/karabiner/*.json`
+- 構文確認: `jq empty config/karabiner/numpad.json`
+
+## WezTerm
+
+- 対象: `config/wezterm/`
+- 起動確認: `wezterm --config-file config/wezterm/wezterm.lua start --always-new-process`
+- GUI を起動できない環境では未実施理由を記録する。
+
+## Tmux
+
+- 対象: `config/tmux/`
+- リロード: `tmux source-file ~/.config/tmux/tmux.conf`
+- セッションがなければ未実施理由を記録する。


### PR DESCRIPTION
## 概要
`AGENTS.md` を 100 行以下の入口に縮約し、共通ルールを `docs/agent-guides/` に分離しました。Claude Code / Codex / GitHub Copilot が同じ正本を参照できる構成に揃えるための変更です。

## 変更内容
- `AGENTS.md` を薄い入口ファイルに整理
- `docs/agent-guides/core.md` `validation.md` `components.md` を追加
- `CLAUDE.md` と `.github/copilot-instructions.md` を参照型に整理
- `config/AGENTS.md` を `config/` 配下限定の補足に縮約

## 影響
- ドキュメント構成のみの変更
- 設定値やリンク挙動には変更なし
- エージェント向け運用ルールの保守先が `docs/agent-guides/` に集約

## 検証
- `wc -l AGENTS.md`
- `git diff -- AGENTS.md CLAUDE.md .github/copilot-instructions.md config/AGENTS.md docs/agent-guides/core.md docs/agent-guides/validation.md docs/agent-guides/components.md`
- `rg -n "docs/agent-guides|config/AGENTS.md" AGENTS.md CLAUDE.md .github/copilot-instructions.md config/AGENTS.md`

## 未実施
- コンポーネント固有の実行検証は未実施
- 理由: 今回はドキュメントのみの変更で、実設定ファイルは変更していないため