### PR TITLE
feat(ai): Claude Code設定ファイルをdotfilesで管理

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ endif
 			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
 		fi; \
 	done
+ifneq ($(DETECTED_OS),windows)
 	$(ECHO) ""
 	$(ECHO) "$(COLOR_CYAN)[File-level: Claude configs]$(COLOR_RESET)"
 	$(Q)for target in \
@@ -333,6 +334,7 @@ endif
 			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
 		fi; \
 	done
+endif
 
 # -----------------------------------------------------------------------------
 # Main link target (auto-detect OS)
@@ -677,10 +679,11 @@ _unlink-claude-skills:
 # -----------------------------------------------------------------------------
 # Internal: Create Claude config file symlinks
 # -----------------------------------------------------------------------------
-# Targets (all OS):
+# Targets (macOS/Linux only — statusline-command.sh requires POSIX sh):
 #   ~/.claude/settings.json            -> dotfiles/ai/claude/settings.json
 #   ~/.claude/statusline-command.sh    -> dotfiles/ai/claude/statusline-command.sh
 _link-claude-configs:
+ifneq ($(DETECTED_OS),windows)
 	$(Q)mkdir -p "$(HOME)/.claude"
 	$(Q)$(MAKE) _create-link \
 		SRC="$(AI_DIR)/claude/settings.json" \
@@ -690,13 +693,18 @@ _link-claude-configs:
 		SRC="$(AI_DIR)/claude/statusline-command.sh" \
 		DEST="$(HOME)/.claude/statusline-command.sh" \
 		FORCE=$(FORCE)
+else
+	$(ECHO) "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) Claude configs (Windows: statusline-command.sh requires POSIX sh)"
+endif
 
 # -----------------------------------------------------------------------------
 # Internal: Remove Claude config file symlinks
 # -----------------------------------------------------------------------------
 _unlink-claude-configs:
+ifneq ($(DETECTED_OS),windows)
 	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.claude/settings.json"
 	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.claude/statusline-command.sh"
+endif
 
 # -----------------------------------------------------------------------------
 # Install BurntToast PowerShell module (Windows only)

--- a/Makefile
+++ b/Makefile
@@ -319,9 +319,22 @@ endif
 			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
 		fi; \
 	done
-ifneq ($(DETECTED_OS),windows)
 	$(ECHO) ""
 	$(ECHO) "$(COLOR_CYAN)[File-level: Claude configs]$(COLOR_RESET)"
+ifeq ($(DETECTED_OS),windows)
+	$(Q)for target in \
+		"$(HOME)/.claude/settings.json" \
+		"$(HOME)/.claude/statusline-command.ps1"; do \
+		if [ -L "$$target" ]; then \
+			link_dest=$$(readlink "$$target"); \
+			echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $$target -> $$link_dest"; \
+		elif [ -e "$$target" ]; then \
+			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (regular file/directory)"; \
+		else \
+			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
+		fi; \
+	done
+else
 	$(Q)for target in \
 		"$(HOME)/.claude/settings.json" \
 		"$(HOME)/.claude/statusline-command.sh"; do \
@@ -679,12 +692,24 @@ _unlink-claude-skills:
 # -----------------------------------------------------------------------------
 # Internal: Create Claude config file symlinks
 # -----------------------------------------------------------------------------
-# Targets (macOS/Linux only — statusline-command.sh requires POSIX sh):
+# macOS/Linux:
 #   ~/.claude/settings.json            -> dotfiles/ai/claude/settings.json
 #   ~/.claude/statusline-command.sh    -> dotfiles/ai/claude/statusline-command.sh
+# Windows:
+#   ~/.claude/settings.json            -> dotfiles/ai/claude/windows/settings.json
+#   ~/.claude/statusline-command.ps1   -> dotfiles/ai/claude/windows/statusline-command.ps1
 _link-claude-configs:
-ifneq ($(DETECTED_OS),windows)
 	$(Q)mkdir -p "$(HOME)/.claude"
+ifeq ($(DETECTED_OS),windows)
+	$(Q)$(MAKE) _create-link \
+		SRC="$(AI_DIR)/claude/windows/settings.json" \
+		DEST="$(HOME)/.claude/settings.json" \
+		FORCE=$(FORCE)
+	$(Q)$(MAKE) _create-link \
+		SRC="$(AI_DIR)/claude/windows/statusline-command.ps1" \
+		DEST="$(HOME)/.claude/statusline-command.ps1" \
+		FORCE=$(FORCE)
+else
 	$(Q)$(MAKE) _create-link \
 		SRC="$(AI_DIR)/claude/settings.json" \
 		DEST="$(HOME)/.claude/settings.json" \
@@ -693,15 +718,16 @@ ifneq ($(DETECTED_OS),windows)
 		SRC="$(AI_DIR)/claude/statusline-command.sh" \
 		DEST="$(HOME)/.claude/statusline-command.sh" \
 		FORCE=$(FORCE)
-else
-	$(ECHO) "  $(COLOR_YELLOW)[SKIP]$(COLOR_RESET) Claude configs (Windows: statusline-command.sh requires POSIX sh)"
 endif
 
 # -----------------------------------------------------------------------------
 # Internal: Remove Claude config file symlinks
 # -----------------------------------------------------------------------------
 _unlink-claude-configs:
-ifneq ($(DETECTED_OS),windows)
+ifeq ($(DETECTED_OS),windows)
+	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.claude/settings.json"
+	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.claude/statusline-command.ps1"
+else
 	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.claude/settings.json"
 	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.claude/statusline-command.sh"
 endif

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,8 @@ COLOR_CYAN := \033[36m
         _link-fish-files _unlink-fish-files \
         _link-karabiner-files _unlink-karabiner-files \
         _link-ai-configs _unlink-ai-configs \
-        _link-claude-skills _unlink-claude-skills
+        _link-claude-skills _unlink-claude-skills \
+        _link-claude-configs _unlink-claude-configs
 
 # -----------------------------------------------------------------------------
 # Default target
@@ -309,6 +310,20 @@ endif
 		[ -d "$$skill_dir" ] || continue; \
 		skill_name=$$(basename "$$skill_dir"); \
 		target="$(HOME)/.claude/skills/$$skill_name"; \
+		if [ -L "$$target" ]; then \
+			link_dest=$$(readlink "$$target"); \
+			echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $$target -> $$link_dest"; \
+		elif [ -e "$$target" ]; then \
+			echo -e "  $(COLOR_YELLOW)[FILE]$(COLOR_RESET) $$target (regular file/directory)"; \
+		else \
+			echo -e "  $(COLOR_RED)[NONE]$(COLOR_RESET) $$target (not found)"; \
+		fi; \
+	done
+	$(ECHO) ""
+	$(ECHO) "$(COLOR_CYAN)[File-level: Claude configs]$(COLOR_RESET)"
+	$(Q)for target in \
+		"$(HOME)/.claude/settings.json" \
+		"$(HOME)/.claude/statusline-command.sh"; do \
 		if [ -L "$$target" ]; then \
 			link_dest=$$(readlink "$$target"); \
 			echo -e "  $(COLOR_GREEN)[LINK]$(COLOR_RESET) $$target -> $$link_dest"; \
@@ -619,6 +634,8 @@ ifeq ($(DETECTED_OS),windows)
 endif
 	@# ~/.claude/skills/<skill> -> dotfiles/ai/skills/<skill>
 	$(Q)$(MAKE) _link-claude-skills FORCE=$(FORCE)
+	@# ~/.claude/settings.json, statusline-command.sh -> dotfiles/ai/claude/
+	$(Q)$(MAKE) _link-claude-configs FORCE=$(FORCE)
 
 # -----------------------------------------------------------------------------
 # Internal: Remove AI tool symlinks
@@ -630,6 +647,7 @@ ifeq ($(DETECTED_OS),windows)
 	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.copilot/hooks/notify.json"
 endif
 	$(Q)$(MAKE) _unlink-claude-skills
+	$(Q)$(MAKE) _unlink-claude-configs
 
 # -----------------------------------------------------------------------------
 # Internal: Create Claude skill symlinks
@@ -655,6 +673,30 @@ _unlink-claude-skills:
 		skill_name=$$(basename "$$skill_dir"); \
 		$(MAKE) _remove-link DEST="$(HOME)/.claude/skills/$$skill_name"; \
 	done
+
+# -----------------------------------------------------------------------------
+# Internal: Create Claude config file symlinks
+# -----------------------------------------------------------------------------
+# Targets (all OS):
+#   ~/.claude/settings.json            -> dotfiles/ai/claude/settings.json
+#   ~/.claude/statusline-command.sh    -> dotfiles/ai/claude/statusline-command.sh
+_link-claude-configs:
+	$(Q)mkdir -p "$(HOME)/.claude"
+	$(Q)$(MAKE) _create-link \
+		SRC="$(AI_DIR)/claude/settings.json" \
+		DEST="$(HOME)/.claude/settings.json" \
+		FORCE=$(FORCE)
+	$(Q)$(MAKE) _create-link \
+		SRC="$(AI_DIR)/claude/statusline-command.sh" \
+		DEST="$(HOME)/.claude/statusline-command.sh" \
+		FORCE=$(FORCE)
+
+# -----------------------------------------------------------------------------
+# Internal: Remove Claude config file symlinks
+# -----------------------------------------------------------------------------
+_unlink-claude-configs:
+	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.claude/settings.json"
+	$(Q)$(MAKE) _remove-link DEST="$(HOME)/.claude/statusline-command.sh"
 
 # -----------------------------------------------------------------------------
 # Install BurntToast PowerShell module (Windows only)

--- a/ai/README.md
+++ b/ai/README.md
@@ -10,8 +10,11 @@ ai/
 │   └── git-commit-jp/
 │       └── SKILL.md                 # 日本語コミットスキル
 ├── claude/
-│   ├── settings.json                # Claude Code ユーザー設定
-│   └── statusline-command.sh        # ステータスライン表示スクリプト
+│   ├── settings.json                # Claude Code ユーザー設定（macOS / Linux）
+│   ├── statusline-command.sh        # ステータスライン表示スクリプト（macOS / Linux）
+│   └── windows/
+│       ├── settings.json            # Claude Code ユーザー設定（Windows）
+│       └── statusline-command.ps1   # ステータスライン表示スクリプト（Windows / pwsh）
 ├── codex/
 │   └── hooks.json                   # Codex CLI の通知フック（macOS）
 └── copilot/
@@ -26,6 +29,8 @@ ai/
 | `ai/skills/` | `~/.agents/skills/` | 全OS |
 | `ai/claude/settings.json` | `~/.claude/settings.json` | macOS / Linux |
 | `ai/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | macOS / Linux |
+| `ai/claude/windows/settings.json` | `~/.claude/settings.json` | Windows |
+| `ai/claude/windows/statusline-command.ps1` | `~/.claude/statusline-command.ps1` | Windows |
 | `ai/codex/hooks.json` | `~/.codex/hooks.json` | 全OS |
 | `ai/copilot/hooks/notify.json` | `~/.copilot/hooks/notify.json` | Windows |
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -9,6 +9,9 @@ ai/
 ├── skills/                          # 共有スキル定義
 │   └── git-commit-jp/
 │       └── SKILL.md                 # 日本語コミットスキル
+├── claude/
+│   ├── settings.json                # Claude Code ユーザー設定
+│   └── statusline-command.sh        # ステータスライン表示スクリプト
 ├── codex/
 │   └── hooks.json                   # Codex CLI の通知フック（macOS）
 └── copilot/
@@ -21,6 +24,8 @@ ai/
 | dotfiles ソース | リンク先 |
 |---------------|---------|
 | `ai/skills/` | `~/.agents/skills/` |
+| `ai/claude/settings.json` | `~/.claude/settings.json` |
+| `ai/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` |
 | `ai/codex/hooks.json` | `~/.codex/hooks.json` |
 | `ai/copilot/hooks/notify.json` | `~/.copilot/hooks/notify.json` |
 
@@ -35,6 +40,8 @@ Claude Code は `~/.agents/skills/` を参照するため、`~/.claude/skills/` 
 - セッションデータ・キャッシュ
 - `~/.codex/rules/default.rules`（過去の承認操作を自動蓄積したファイル）
 - `~/.claude/skills/*.skill`（スキルディレクトリの自動生成バイナリ）
+- `~/.claude/history.jsonl`, `~/.claude/stats-cache.json`（自動生成データ）
+- `~/.claude/CLAUDE.md`（プロジェクト固有の指示ファイル）
 
 ## 新しいスキルを追加する場合
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -21,13 +21,13 @@ ai/
 
 ## シンボリックリンクのマッピング
 
-| dotfiles ソース | リンク先 |
-|---------------|---------|
-| `ai/skills/` | `~/.agents/skills/` |
-| `ai/claude/settings.json` | `~/.claude/settings.json` |
-| `ai/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` |
-| `ai/codex/hooks.json` | `~/.codex/hooks.json` |
-| `ai/copilot/hooks/notify.json` | `~/.copilot/hooks/notify.json` |
+| dotfiles ソース | リンク先 | 対応OS |
+|---------------|---------|--------|
+| `ai/skills/` | `~/.agents/skills/` | 全OS |
+| `ai/claude/settings.json` | `~/.claude/settings.json` | macOS / Linux |
+| `ai/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | macOS / Linux |
+| `ai/codex/hooks.json` | `~/.codex/hooks.json` | 全OS |
+| `ai/copilot/hooks/notify.json` | `~/.copilot/hooks/notify.json` | Windows |
 
 リンクは `make link` で自動適用される（macOS / Linux / Windows 対応）。
 Claude Code は `~/.agents/skills/` を参照するため、`~/.claude/skills/` への個別リンクは不要。

--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "enabledPlugins": {
+    "example-skills@anthropic-agent-skills": true,
+    "document-skills@anthropic-agent-skills": true
+  },
+  "language": "Japanese",
+  "editorMode": "vim",
+  "statusLine": {
+    "type": "command",
+    "command": "sh ~/.claude/statusline-command.sh"
+  }
+}

--- a/ai/claude/statusline-command.sh
+++ b/ai/claude/statusline-command.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+input=$(cat)
+
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // empty')
+model=$(echo "$input" | jq -r '.model.display_name // empty')
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+five_hour_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+seven_day_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+
+# Git branch (skip optional locks to avoid contention)
+git_branch=""
+if [ -n "$cwd" ] && git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
+  git_branch=$(git -C "$cwd" -c core.hooksPath=/dev/null symbolic-ref --short HEAD 2>/dev/null \
+    || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
+fi
+
+# Build status line parts
+parts=""
+
+# Current directory (show home as ~)
+if [ -n "$cwd" ]; then
+  home="$HOME"
+  display_dir="${cwd#$home}"
+  if [ "$display_dir" != "$cwd" ]; then
+    display_dir="~$display_dir"
+  fi
+  parts="$display_dir"
+fi
+
+# Git branch
+if [ -n "$git_branch" ]; then
+  parts="$parts  $git_branch"
+fi
+
+# Model name
+if [ -n "$model" ]; then
+  parts="$parts  $model"
+fi
+
+# Context window usage
+if [ -n "$used_pct" ]; then
+  used_fmt=$(printf "%.0f" "$used_pct")
+  parts="$parts  ctx:${used_fmt}%"
+fi
+
+# 5-hour rate limit usage (only shown when available, i.e. after first API response)
+if [ -n "$five_hour_pct" ]; then
+  five_fmt=$(printf "%.0f" "$five_hour_pct")
+  parts="$parts  5h:${five_fmt}%"
+fi
+
+# 7-day rate limit usage (only shown when available)
+if [ -n "$seven_day_pct" ]; then
+  seven_fmt=$(printf "%.0f" "$seven_day_pct")
+  parts="$parts  7d:${seven_fmt}%"
+fi
+
+printf "%s" "$parts"

--- a/ai/claude/windows/settings.json
+++ b/ai/claude/windows/settings.json
@@ -1,0 +1,12 @@
+{
+  "enabledPlugins": {
+    "example-skills@anthropic-agent-skills": true,
+    "document-skills@anthropic-agent-skills": true
+  },
+  "language": "Japanese",
+  "editorMode": "vim",
+  "statusLine": {
+    "type": "command",
+    "command": "pwsh -NoProfile -NonInteractive -File ~/.claude/statusline-command.ps1"
+  }
+}

--- a/ai/claude/windows/statusline-command.ps1
+++ b/ai/claude/windows/statusline-command.ps1
@@ -1,0 +1,43 @@
+$jsonText = [Console]::In.ReadToEnd()
+if (-not $jsonText.Trim()) { exit 0 }
+
+$json = $jsonText | ConvertFrom-Json
+
+$cwd         = if ($json.workspace.current_dir) { $json.workspace.current_dir } else { $json.cwd }
+$model       = $json.model.display_name
+$usedPct     = $json.context_window.used_percentage
+$fiveHrPct   = $json.rate_limits.five_hour.used_percentage
+$sevenDayPct = $json.rate_limits.seven_day.used_percentage
+
+# Git branch
+$gitBranch = ""
+if ($cwd) {
+    $null = git -C $cwd rev-parse --git-dir 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        $gitBranch = git -C $cwd -c core.hooksPath=NUL symbolic-ref --short HEAD 2>$null
+        if (-not $gitBranch) {
+            $gitBranch = git -C $cwd rev-parse --short HEAD 2>$null
+        }
+    }
+}
+
+$parts = @()
+
+# Current directory (substitute USERPROFILE with ~)
+if ($cwd) {
+    $homeDir = $env:USERPROFILE
+    if ($cwd.StartsWith($homeDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $displayDir = "~" + $cwd.Substring($homeDir.Length)
+    } else {
+        $displayDir = $cwd
+    }
+    $parts += $displayDir
+}
+
+if ($gitBranch)          { $parts += $gitBranch }
+if ($model)              { $parts += $model }
+if ($null -ne $usedPct)     { $parts += "ctx:$([math]::Round($usedPct))%" }
+if ($null -ne $fiveHrPct)   { $parts += "5h:$([math]::Round($fiveHrPct))%" }
+if ($null -ne $sevenDayPct) { $parts += "7d:$([math]::Round($sevenDayPct))%" }
+
+[Console]::Write($parts -join "  ")

--- a/docs/plans/claude-config-management.md
+++ b/docs/plans/claude-config-management.md
@@ -1,0 +1,43 @@
+# Claude Code 設定ファイルの dotfiles 管理
+
+## 目的
+
+Claude Code のユーザー設定（`settings.json`）とステータスライン表示スクリプト（`statusline-command.sh`）を dotfiles リポジトリで管理し、シンボリックリンクで `~/.claude/` に適用する。
+
+## 対象ファイル
+
+| dotfiles ソース | リンク先 |
+|---|---|
+| `ai/claude/settings.json` | `~/.claude/settings.json` |
+| `ai/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` |
+
+## 変更内容
+
+- `ai/claude/` ディレクトリを新設し、上記2ファイルを配置
+- `Makefile` に `_link-claude-configs` / `_unlink-claude-configs` ターゲットを追加
+- `_link-ai-configs` / `_unlink-ai-configs` から上記ターゲットを呼び出す
+- `status` ターゲットに `[File-level: Claude configs]` セクションを追加
+- `ai/README.md` にマッピングと除外ファイルの説明を追記
+
+## 除外（管理しない）ファイル
+
+- `history.jsonl`, `stats-cache.json`（自動生成）
+- `backups/`, `cache/`, `sessions/` 等（自動生成ディレクトリ）
+- `CLAUDE.md`（プロジェクト固有の指示ファイル、リポジトリルートで別管理）
+- `skills/*.skill`（自動生成バイナリ）
+
+## 適用方法
+
+```sh
+make link FORCE=1
+```
+
+既存の実ファイルを上書きしてシンボリックリンクを作成する。
+
+## 検証コマンド
+
+```sh
+make check
+make status
+ls -la ~/.claude/settings.json ~/.claude/statusline-command.sh
+```


### PR DESCRIPTION
## Summary

- `ai/claude/` を新設し `settings.json`・`statusline-command.sh` を dotfiles で管理
- `ai/claude/windows/` を新設し Windows向け `settings.json`・`statusline-command.ps1` を追加
- `Makefile` に `_link-claude-configs` / `_unlink-claude-configs` ターゲットを追加し、`make link` で `~/.claude/` へのシンボリックリンクを自動作成（OS別に分岐）
- `make status` に `[File-level: Claude configs]` セクションを追加（全OS対応）
- `ai/README.md` にディレクトリ構成・マッピング表・除外ファイルを追記

## シンボリックリンクのマッピング

| dotfiles ソース | リンク先 | 対応OS |
|---|---|---|
| `ai/claude/settings.json` | `~/.claude/settings.json` | macOS / Linux |
| `ai/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | macOS / Linux |
| `ai/claude/windows/settings.json` | `~/.claude/settings.json` | Windows |
| `ai/claude/windows/statusline-command.ps1` | `~/.claude/statusline-command.ps1` | Windows |

Windows版は `pwsh`（PowerShell Core）を使用し、sh版と同等のフォーマット（`~/path  branch  model  ctx:X%  5h:X%  7d:X%`）で出力する。

## Codex レビュー対応

- **P2**: `statusline-command.sh` はPOSIX sh前提のためWindows非対応 → `ai/claude/windows/` を新設してOS別にファイルを分離し、Makefileの`ifeq(windows)`で切り替えるよう対応

## Test plan

- [ ] `make check` でOS検出が正常に動作すること
- [ ] (macOS/Linux) `make link FORCE=1` で `~/.claude/settings.json` と `~/.claude/statusline-command.sh` がシンボリックリンクになること
- [ ] (Windows) `make link FORCE=1` で `~/.claude/settings.json` と `~/.claude/statusline-command.ps1` がシンボリックリンクになること
- [ ] `make status` に `[File-level: Claude configs]` セクションが表示されること
- [ ] `make unlink` でリンクが正常に削除されること
- [ ] (Windows) `statusline-command.ps1` が statusline に正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)