### PR TITLE
feat(ai): Claude Codeのエージェント停止通知フックを追加

### DIFF
--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -8,5 +8,17 @@
   "statusLine": {
     "type": "command",
     "command": "sh ~/.claude/statusline-command.sh"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude Codeのエージェント作業が停止しました\" with title \"Claude Code\" sound name \"Glass\"'"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/ai/claude/windows/settings.json
+++ b/ai/claude/windows/settings.json
@@ -8,5 +8,17 @@
   "statusLine": {
     "type": "command",
     "command": "pwsh -NoProfile -NonInteractive -File ~/.claude/statusline-command.ps1"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -Command \"Import-Module BurntToast; New-BurntToastNotification -Text 'Claude Code', 'エージェントの作業が停止しました'\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/plans/claude-stop-notification.md
+++ b/docs/plans/claude-stop-notification.md
@@ -1,0 +1,60 @@
+# Claude Code エージェント停止通知の追加
+
+## 目的
+
+Claude Code でエージェントの作業が停止した際（Stop イベント）に OS ネイティブ通知を表示する。
+macOS / Linux（osascript）と Windows（BurntToast）の両プラットフォームに対応する。
+
+## 変更ファイル
+
+| ファイル | 内容 |
+|---------|------|
+| `ai/claude/settings.json` | macOS / Linux 向け Stop フックを追加 |
+| `ai/claude/windows/settings.json` | Windows 向け Stop フックを追加 |
+
+## 実装内容
+
+### macOS / Linux（osascript）
+
+```json
+"hooks": {
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "osascript -e 'display notification \"Claude Codeのエージェント作業が停止しました\" with title \"Claude Code\" sound name \"Glass\"'"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Windows（BurntToast）
+
+```json
+"hooks": {
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "powershell.exe -NoProfile -Command \"Import-Module BurntToast; New-BurntToastNotification -Text 'Claude Code', 'エージェントの作業が停止しました'\""
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Makefile への影響
+
+なし。`_link-claude-configs` が既に両ファイルを `~/.claude/settings.json` へリンクする。
+
+## 検証
+
+- `jq . ai/claude/settings.json` — JSON バリデーション
+- `jq . ai/claude/windows/settings.json` — JSON バリデーション
+- `make check` — リンク構成の整合性確認
+- 実環境での動作確認（Claude Code でタスク完了後に OS 通知が届くことを確認）


### PR DESCRIPTION
## Summary

- `ai/claude/settings.json` に macOS/Linux 向け Stop フックを追加（osascript + Glass 音）
- `ai/claude/windows/settings.json` に Windows 向け Stop フックを追加（BurntToast / PowerShell）
- 既存の `_link-claude-configs` がリンクを管理するため Makefile の変更は不要

## Background

Codex CLI（macOS）と GitHub Copilot（Windows）には既に同等の通知フックが実装済み。
同じパターンを Claude Code の `settings.json` に追加することで、エージェント作業停止時に OS ネイティブ通知を表示できる。

## Test plan

- [ ] `jq . ai/claude/settings.json` — JSON バリデーション
- [ ] `jq . ai/claude/windows/settings.json` — JSON バリデーション
- [ ] `make check` — リンク構成の整合性確認
- [ ] macOS: `make link` 後に Claude Code でタスクを完了させ、OS 通知（サウンド付き）が届くことを確認
- [ ] Windows: `make link` 後に同様に確認（BurntToast モジュールが必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)