### PR TITLE
feat: add Windows Codex notification hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -631,7 +631,8 @@ _unlink-karabiner-files:
 # -----------------------------------------------------------------------------
 # Targets (all OS):
 #   ~/.agents/skills              -> dotfiles/ai/skills               (directory)
-#   ~/.codex/hooks.json           -> dotfiles/ai/codex/hooks.json     (file)
+#   ~/.codex/hooks.json           -> dotfiles/ai/codex/hooks.json     (file, macOS/Linux)
+#   ~/.codex/hooks.json           -> dotfiles/ai/codex/windows/hooks.json (file, Windows)
 # Targets (Windows only):
 #   ~/.copilot/agents             -> dotfiles/ai/copilot/agents       (directory)
 #   ~/.copilot/hooks/notify.json  -> dotfiles/ai/copilot/hooks/notify.json (file)
@@ -642,12 +643,21 @@ _link-ai-configs:
 		SRC="$(AI_DIR)/skills" \
 		DEST="$(HOME)/.agents/skills" \
 		FORCE=$(FORCE)
+ifeq ($(DETECTED_OS),windows)
+	@# ~/.codex/hooks.json -> dotfiles/ai/codex/windows/hooks.json
+	$(Q)mkdir -p "$(HOME)/.codex"
+	$(Q)$(MAKE) _create-link \
+		SRC="$(AI_DIR)/codex/windows/hooks.json" \
+		DEST="$(HOME)/.codex/hooks.json" \
+		FORCE=$(FORCE)
+else
 	@# ~/.codex/hooks.json -> dotfiles/ai/codex/hooks.json
 	$(Q)mkdir -p "$(HOME)/.codex"
 	$(Q)$(MAKE) _create-link \
 		SRC="$(AI_DIR)/codex/hooks.json" \
 		DEST="$(HOME)/.codex/hooks.json" \
 		FORCE=$(FORCE)
+endif
 ifeq ($(DETECTED_OS),windows)
 	@# ~/.copilot/agents -> dotfiles/ai/copilot/agents
 	$(Q)mkdir -p "$(HOME)/.copilot"

--- a/ai/README.md
+++ b/ai/README.md
@@ -16,7 +16,9 @@ ai/
 │       ├── settings.json            # Claude Code ユーザー設定（Windows）
 │       └── statusline-command.ps1   # ステータスライン表示スクリプト（Windows / pwsh）
 ├── codex/
-│   └── hooks.json                   # Codex CLI の通知フック（macOS）
+│   ├── hooks.json                   # Codex CLI の通知フック（macOS / Linux）
+│   └── windows/
+│       └── hooks.json               # Codex CLI の通知フック（Windows）
 └── copilot/
     ├── agents/                      # GitHub Copilot カスタムエージェント
     └── hooks/
@@ -32,7 +34,8 @@ ai/
 | `ai/claude/statusline-command.sh` | `~/.claude/statusline-command.sh` | macOS / Linux |
 | `ai/claude/windows/settings.json` | `~/.claude/settings.json` | Windows |
 | `ai/claude/windows/statusline-command.ps1` | `~/.claude/statusline-command.ps1` | Windows |
-| `ai/codex/hooks.json` | `~/.codex/hooks.json` | 全OS |
+| `ai/codex/hooks.json` | `~/.codex/hooks.json` | macOS / Linux |
+| `ai/codex/windows/hooks.json` | `~/.codex/hooks.json` | Windows |
 | `ai/copilot/agents/` | `~/.copilot/agents/` | Windows |
 | `ai/copilot/hooks/notify.json` | `~/.copilot/hooks/notify.json` | Windows |
 

--- a/ai/codex/windows/hooks.json
+++ b/ai/codex/windows/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -Command \"Import-Module BurntToast; New-BurntToastNotification -Text 'Codex CLI', 'Codexの処理が停止しました' -Sound 'Alarm2'\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation
- Codex の停止通知を macOS の仕組みと同様に Windows でも利用できるようにし、Claude/Copilot と同様に Codex でも OS ごとの通知設定を持たせるためです。
- Windows 環境では PowerShell の BurntToast を使った通知を想定しており、環境に応じたシンボリックリンクで適切な hooks を配置する必要がありました。

### Description
- `ai/codex/windows/hooks.json` を追加し、`Stop` フックで `BurntToast` による PowerShell 通知を行う設定を追加しました。  
- `Makefile` の `_link-ai-configs` を OS 判定で分岐させ、Windows では `ai/codex/windows/hooks.json` を、macOS/Linux では既存の `ai/codex/hooks.json` を `~/.codex/hooks.json` にリンクするように変更しました。  
- `ai/README.md` のディレクトリ構成とリンクマッピングを更新して、Codex hooks の macOS/Linux と Windows の対応を明記しました。

### Testing
- `jq . ai/codex/hooks.json` と `jq . ai/codex/windows/hooks.json` による JSON 構文チェックを実行し成功しました。  
- `make check` と `make status` を実行して OS 検出とリンク状態表示に問題がないことを確認しました。  
- `make -n DETECTED_OS=windows _link-ai-configs` のドライランを実行して、Windows 分岐で `ai/codex/windows/hooks.json` がリンクされるロジックを確認しました。  
- `git diff --check` を実行して差分に問題がないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fce58284c83208f6974aabbb98da8)